### PR TITLE
GitHub Actions Workflow for Pull Request Checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,7 +51,7 @@ jobs:
         run: pnpm install
       - name: Run test build
         run: pnpm build
-  
+
   dependency-review:
     name: Check for security/license issues
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,3 +51,10 @@ jobs:
         run: pnpm install
       - name: Run test build
         run: pnpm build
+  
+  dependency-review:
+    name: Check for security/license issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NODE_INSTALL_VERSION: 20.x
+  PNPM_INSTALL_VERSION: 8
+
 jobs:
   lint:
     name: Linter check
@@ -21,10 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: ${{ env.PNPM_INSTALL_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: ${{ env.NODE_INSTALL_VERSION }}
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
@@ -38,10 +42,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: ${{ env.PNPM_INSTALL_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: ${{ env.NODE_INSTALL_VERSION }}
           cache: pnpm
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,49 @@
+name: Run PR checks
+run-name: Checks for PR#${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Linter check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run prettier
+        run: pnpm lint
+
+  build:
+    name: Build check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run test build
+        run: pnpm build


### PR DESCRIPTION
# Summary

This is an action that will run every time a PR is opened targeting the `main` branch.  
It is set up to run the following:
- linting with prettier
- a test Docusaurus build, which will be discarded when the workflow finishes running

If one or more of these jobs fail, they will result in a little red X in the checks section of the PR merge area.

I've only ever been responsible for CI for personal projects, so I welcome feedback. I also find it terribly difficult to test GitHub Actions workflows, so here's hoping it works on the first try.

# Design Decisions
## Action Dependencies
In addition to standard GitHub-created actions, this uses the [@pnpm/action-setup](https://github.com/pnpm/action-setup) action provided by the maintainers of the `pnpm` package manager itself. While they are not technically a "verified Marketplace publisher," this action is nevertheless recommended by GitHub in their [actions/setup-node documentation](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data) and it seems unlikely that the pnpm maintainers would poison their own GitHub action.
## Workflow Design
I looked at a lot of prominent Node-based packages on GitHub to see how they designed their PR-related workflows, and have tried to incorporate what I learned from them.
### Job Definitions
There is a lot of redundancy in the job definitions (checkout, installing pnpm, installing Node, installing dependencies). This could be addressed by factoring it out into a separate composite action, or running the linter and build as consecutive steps within a single job, but I found no other prominent repository that did it like this.

Keeping them distinct adds a small maintenance overhead whenever we want to change things common to all jobs, but also means that we can tailor them individually when appropriate. For example it may be desirable to test the build on multiple versions of Node, but we are probably fine running the linter on only one version.

I've also specified `latest` as the version of `pnpm` to install to reduce maintenance, but I'm not sure if that's appropriate or if it's common for package managers to have meaningful breaking changes on major version bumps. We might watch to change it to `8` explicitly.
### Concurrency
I made the decision to assign this workflow to a workflow-specific concurrency group. This is basically to stop rapid-fire commits on a *single* PR from launching multiple linting and building jobs when we really only care about the latest. This will not block workflow runs on other open PRs and will not interfere with the eventual deploy workflow.

I've also enabled the `cancel-in-progress` flag because there are no side-effects to canceling a linting run or a test build, and it just prevents running jobs that are no longer relevant when a newer commit has been added.

### Additional Checks to Consider
We've also not talked about how to handle package bumps required to address security vulnerabilities, and I see `dependabot` already has 2 alerts for us.

I had considered adding a third check using the official GitHub [dependency-review-action](https://github.com/actions/dependency-review-action) action, which can be configured to block a PR from being merged if one or both of the following are true:
- The package lockfile being committed has dependencies that are associated with security alerts
- The package lockfile being committed has packages with incompatible licenses

One the one hand, I like the idea of blocking PRs until vulnerable packages are addressed, but on the other hand this could lead to the addition of security-related commits to PRs that have nothing to do with security. Maybe they would be better in separate `dependabot`-initiated PRs created at whatever interval the bot is configured to check. I would like to hear other opinions on this.