### PR TITLE
Create vscode defaults for prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "editor.renderFinalNewline": "dimmed",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "files.autoSave": "off"
+}


### PR DESCRIPTION
adds format on save and other stuff to vscode workspace settings. Happy to discuss these decisions, though they can be overridden by local settings.