### PR TITLE
update vscode config to match prettier code style regarding indentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
   "files.insertFinalNewline": true,
   "editor.renderFinalNewline": "dimmed",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "files.autoSave": "off"
+  "files.autoSave": "off",
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2
 }


### PR DESCRIPTION
Sets local preferences for VSCode so that indentation will match the `prettier` style. This fixes indentation rendering and indent amount for those of us with global configs that are not indent-is-2-spaces.