### PR TITLE
Modify Docusaurus config to support custom domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ const config = {
 
   // Deployment details
   url: `https://${GITHUB_ORG}.github.io`,
-  baseUrl: `/${GITHUB_PROJECT}/`,
+  baseUrl: `/`,
 
   // GitHub Pages config for CLI deployment
   organizationName: GITHUB_ORG,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   //favicon: 'img/favicon.ico',
 
   // Deployment details
-  url: `https://${GITHUB_ORG}.github.io`,
+  url: `https://wiki.hackmud.com`,
   baseUrl: `/`,
 
   // GitHub Pages config for CLI deployment


### PR DESCRIPTION
### Problem
https://wiki.hackmud.com has been set up by Sean, but Docusaurus is still expecting to be served from the `/hackmud_wiki` path associated with the original Pages URL.

### Solution
Changes `url` and `baseUrl` in the Docusaurus config so that the site is served from the correct path and intra-site links work correctly with the new custom domain.