### PR TITLE
Change to ESM syntax

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,4 +94,4 @@ const config = {
   },
 };
 
-module.exports = config;
+export default config;


### PR DESCRIPTION
Docusaurus v3 supports using ESM syntax in project files.

This changes our existing code that uses CommonJS syntax (only `docusaurus.config.js` at the moment).

NB: this is *not* the same as setting `"type":"module"` in `package.json`, which Docusaurus does not support in my testing.
Instead, this uses ESM syntax in Docusaurus project files, which are transpiled behind the scenes by Docusaurus at build time.

Fixes #47.