### PR TITLE
patch: Change to ESM syntax 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
       "@docusaurus/theme-classic",
       // See: https://docusaurus.io/docs/api/themes/@docusaurus/theme-classic#configuration
       {
-        customCss: require.resolve("./src/css/custom.css"),
+        customCss: "./src/css/custom.css",
       },
     ],
   ],


### PR DESCRIPTION
The `require.resolve` for custom css configuration is unnecessary (docusaurus will attempt to import it from the filename), and following on from #48 it should probably just be removed.