### PR TITLE
Integrate wiki-link plugin

### DIFF
--- a/docs/create_a_page.mdx
+++ b/docs/create_a_page.mdx
@@ -1,0 +1,6 @@
+---
+title: Create a Page
+unlisted: true
+---
+
+Create a page [here](https://github.com/comcode-org/hackmud_wiki).

--- a/docs/wikilink_demo.mdx
+++ b/docs/wikilink_demo.mdx
@@ -1,0 +1,19 @@
+---
+slug: /wikilink_demo
+title: Wiki-Link Demo
+unlisted: true
+---
+
+This is another page. Check out [[Home]] or [[xena.puppies]].
+
+## Section 1
+
+Ut et eros et justo consectetur semper dictum nec orci. Donec tempor mi orci. In hac habitasse platea dictumst. Phasellus eu elementum mauris. Donec mollis lacus ut dolor rutrum, at ultrices enim cursus. Proin ac velit urna. Vestibulum sollicitudin metus est. Fusce in libero sed lorem tincidunt tempus. Cras consequat urna eu semper interdum. Morbi ornare consectetur tortor, ut sodales est tincidunt id. Donec ipsum enim, aliquam vitae pharetra sagittis, maximus sit amet ipsum. Phasellus a lorem feugiat, iaculis risus vel, mollis lacus. Etiam rutrum cursus ante, at semper mauris tristique ac. Morbi consequat lacus sapien, volutpat dapibus tortor vehicula eu. Suspendisse vulputate, nisi eu scelerisque dapibus, lacus massa faucibus justo, facilisis faucibus ipsum est sodales risus.
+
+## Section 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor ornare orci, vel gravida velit venenatis eget. Sed auctor, sem vitae consectetur egestas, tellus purus gravida nisl, et porta ipsum urna eu mauris. Morbi ultricies libero in iaculis eleifend. Nulla facilisi. Vivamus mattis tempus nisi, nec ultrices mauris tristique in. Nunc pulvinar aliquam lectus nec gravida. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In pellentesque massa et arcu auctor, porttitor ultrices dolor sagittis. Nulla pellentesque volutpat risus id congue.
+
+### Section 2.1
+
+Nullam placerat elit nec turpis imperdiet molestie non ut lacus. Pellentesque a molestie nibh. Fusce viverra egestas felis, et porttitor magna efficitur et. Aenean gravida quam et commodo dignissim. Duis nec nibh dolor. Cras vestibulum in odio vitae posuere. Donec convallis maximus consequat. Nam et mattis purus. Curabitur iaculis quam ligula, at facilisis elit egestas sit amet. Nam a ullamcorper nisi, quis luctus leo. Ut eleifend dui odio, ut maximus elit lobortis id. Phasellus bibendum, purus in bibendum tincidunt, ligula neque vulputate nulla, at sollicitudin lacus lorem vel risus. Nam consectetur scelerisque orci eget convallis. In nec ornare dui. Pellentesque eu felis imperdiet, euismod leo et, euismod ex. Nullam nec dignissim sapien, eu tempor erat.

--- a/docs/wikilink_demo.mdx
+++ b/docs/wikilink_demo.mdx
@@ -1,10 +1,31 @@
 ---
-slug: /wikilink_demo
 title: Wiki-Link Demo
+
+alias:
+  - wikilink_example
+  - wikilink_test
+
+# can also use:
+# alias: [wikilink_example, wikilink_test]
+
+# as well as singular alias:
+# alias: wikilink_example
+
 unlisted: true
 ---
 
 This is another page. Check out [[Home]] or [[xena.puppies]].
+
+Example links:
+
+- [[Wiki-Link Demo]]
+- [[WiKiLiNK demo]]
+- [[/wikilink_demo]]
+
+Aliases:
+
+- [[wikilink_example]]
+- [[wikilink_test]]
 
 ## Section 1
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,5 @@
 // @ts-check
+import pluginContentDocsWrapper from "./src/plugins/pluginContentDocsWrapper";
 
 const GITHUB_ORG = "comcode-org";
 const GITHUB_PROJECT = "hackmud_wiki";
@@ -29,7 +30,7 @@ const config = {
   // Installed plugins
   plugins: [
     [
-      "@docusaurus/plugin-content-docs",
+      pluginContentDocsWrapper, // wraps @docusaurus/plugin-content-docs
       // See: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#configuration
       {
         // Path of the docs plugin relative to the root. Since it's the only

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@docusaurus/plugin-content-docs": "^3.0.1",
     "@docusaurus/theme-classic": "^3.0.1",
     "@mdx-js/react": "^3.0.0",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "remark-wiki-link": "^2.0.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   react:
     specifier: ^18.2.0
     version: 18.2.0
+  remark-wiki-link:
+    specifier: ^2.0.1
+    version: 2.0.1
 
 devDependencies:
   '@docusaurus/module-type-aliases':
@@ -2910,11 +2913,23 @@ packages:
   /character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
+  /character-entities-legacy@1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+    dev: false
+
   /character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  /character-entities@1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+    dev: false
+
   /character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  /character-reference-invalid@1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+    dev: false
 
   /character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
@@ -4551,8 +4566,19 @@ packages:
     resolution: {integrity: sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==}
     engines: {node: '>= 10'}
 
+  /is-alphabetical@1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+    dev: false
+
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  /is-alphanumerical@1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+    dev: false
 
   /is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
@@ -4580,6 +4606,10 @@ packages:
     dependencies:
       has: 1.0.3
 
+  /is-decimal@1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
+    dev: false
+
   /is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -4605,6 +4635,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+
+  /is-hexadecimal@1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+    dev: false
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -4902,6 +4936,10 @@ packages:
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  /longest-streak@2.0.4:
+    resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==}
+    dev: false
+
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -5125,6 +5163,17 @@ packages:
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
 
+  /mdast-util-to-markdown@0.6.5:
+    resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
+    dependencies:
+      '@types/unist': 2.0.10
+      longest-streak: 2.0.4
+      mdast-util-to-string: 2.0.0
+      parse-entities: 2.0.0
+      repeat-string: 1.6.1
+      zwitch: 1.0.5
+    dev: false
+
   /mdast-util-to-markdown@2.1.0:
     resolution: {integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==}
     dependencies:
@@ -5137,10 +5186,21 @@ packages:
       unist-util-visit: 5.0.0
       zwitch: 2.0.4
 
+  /mdast-util-to-string@2.0.0:
+    resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
+    dev: false
+
   /mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
     dependencies:
       '@types/mdast': 4.0.3
+
+  /mdast-util-wiki-link@0.1.2:
+    resolution: {integrity: sha512-DTcDyOxKDo3pB3fc0zQlD8myfQjYkW4hazUKI9PUyhtoj9JBeHC2eIdlVXmaT22bZkFAVU2d47B6y2jVKGoUQg==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      mdast-util-to-markdown: 0.6.5
+    dev: false
 
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -5328,6 +5388,12 @@ packages:
       micromark-extension-mdxjs-esm: 3.0.0
       micromark-util-combine-extensions: 2.0.0
       micromark-util-types: 2.0.0
+
+  /micromark-extension-wiki-link@0.0.4:
+    resolution: {integrity: sha512-dJc8AfnoU8BHkN+7fWZvIS20SMsMS1ZlxQUn6We67MqeKbOiEDZV5eEvCpwqGBijbJbxX3Kxz879L4K9HIiOvw==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+    dev: false
 
   /micromark-factory-destination@2.0.0:
     resolution: {integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==}
@@ -5787,6 +5853,17 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+
+  /parse-entities@2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+    dev: false
 
   /parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
@@ -6695,6 +6772,14 @@ packages:
       mdast-util-to-markdown: 2.1.0
       unified: 11.0.4
 
+  /remark-wiki-link@2.0.1:
+    resolution: {integrity: sha512-F8Eut1E7GWfFm4ZDTI6/4ejeZEHZgnVk6E933Yqd/ssYsc4AyI32aGakxwsGcEzbbE7dkWi1EfLlGAdGgOZOsA==}
+    dependencies:
+      '@babel/runtime': 7.23.1
+      mdast-util-wiki-link: 0.1.2
+      micromark-extension-wiki-link: 0.0.4
+    dev: false
+
   /renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
     dependencies:
@@ -6703,6 +6788,11 @@ packages:
       htmlparser2: 6.1.0
       lodash: 4.17.21
       strip-ansi: 6.0.1
+
+  /repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -7836,6 +7926,10 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+
+  /zwitch@1.0.5:
+    resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+    dev: false
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2,7 +2,6 @@
  * WIKILINK CLASSES
  */
 /*.wikilink {}*/
-.wikilink-new,
-.wikilink-new:hover {
+a.wikilink-new {
   color: var(--ifm-color-danger);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,0 +1,8 @@
+/**
+ * WIKILINK CLASSES
+ */
+/*.wikilink {}*/
+.wikilink-new,
+.wikilink-new:hover {
+  color: var(--ifm-color-danger);
+}

--- a/src/plugins/pluginContentDocsWrapper.ts
+++ b/src/plugins/pluginContentDocsWrapper.ts
@@ -1,0 +1,96 @@
+import pluginContentDocs, {
+  LoadedContent,
+  LoadedVersion,
+  PluginOptions,
+} from "@docusaurus/plugin-content-docs";
+import { LoadContext, Plugin } from "@docusaurus/types";
+import remarkWikiLink from "remark-wiki-link";
+
+function getCurrentVersion(content: LoadedContent): LoadedVersion {
+  return content.loadedVersions.find(
+    (version) => version.versionName === "current",
+  );
+}
+
+function getConfiguredWikiLinkPlugin(
+  content: LoadedContent,
+): [Function, object] {
+  const docs = getCurrentVersion(content).docs;
+  return [
+    remarkWikiLink,
+    {
+      // class attached to all generated links
+      wikiLinkClassName: "wikilink",
+
+      // class attached to resolved links not found in permalinks
+      newClassName: "wikilink-new",
+
+      // list of permalinks that exist
+      permalinks: docs.map((doc) => doc.permalink),
+
+      // href path that the plugin generates based on the permalink
+      hrefTemplate: function (permalink: string): string {
+        return permalink;
+      },
+
+      /**
+       * 1. A wikilink can contain either a page name or slug.
+       *    - e.g. `[[Name]]` `[[slug/path]]` `[[Alias:...]]`
+       *
+       * 2. The resolver will return a permalink for a page where the link name
+       *    is the title or the link slug is a suffix* of the permalink.
+       *    - *bar/baz matches foo/bar/baz but not foobar/baz
+       *
+       * 3. The resolver will return a permalink for a page at the highest
+       *    directory level possible.
+       *    - e.g. bar/baz matches /foo/bar/baz but prefers /bar/baz if present
+       *
+       * 4. The resolver will return the slug instead if no matching docs exist.
+       */
+      pageResolver: function (pageName: string): string[] {
+        const name = pageName.toLowerCase();
+        const slugReference = name[0] === "/" ? name : "/" + name;
+
+        const relevantDocs = docs.filter(
+          (doc) =>
+            doc.title.toLowerCase() === name ||
+            doc.permalink.endsWith(slugReference),
+        );
+
+        if (relevantDocs.length <= 0) {
+          return [slugReference];
+        }
+
+        const topLevelRelevantDoc = relevantDocs.reduce((docA, docB) => {
+          const depthA = docA.permalink.split("/").length;
+          const depthB = docB.permalink.split("/").length;
+          return depthA <= depthB ? docA : docB;
+        });
+
+        return [topLevelRelevantDoc.permalink];
+      },
+    },
+  ];
+}
+
+/**
+ * Returns a copy of the `@docusaurus/plugin-content-docs` plugin.
+ *
+ * The `contentLoaded` method is overridden to inject the `remark-wiki-link`
+ * plugin and a configuration for it.
+ */
+export default async function pluginContentDocsWrapper(
+  context: LoadContext,
+  options: PluginOptions,
+): Promise<Plugin<LoadedContent>> {
+  const originalPlugin = await pluginContentDocs(context, options);
+  return {
+    ...originalPlugin,
+    contentLoaded: function (args) {
+      options.remarkPlugins.push(getConfiguredWikiLinkPlugin(args.content));
+      return originalPlugin.contentLoaded(args);
+    },
+  };
+}
+
+export { validateOptions } from "@docusaurus/plugin-content-docs/lib/options.js";


### PR DESCRIPTION
This PR:
- implements a wrapper for the @docusaurus/plugin-content-docs plugin
- integrates the remark-wiki-link plugin into Docusaurus, which fixes #32
- adds some associated styling
- adds unlisted[^1] page to demo some of this: [Wiki-Link Demo](https://wiki.hackmud.com/wikilink_demo) (not live so replace the hostname)
- adds another unlisted page that broken/new wiki links point to, which we should fill out at a later stage: [Create a Page](https://wiki.hackmud.com/create_a_page)

[^1]: Unlisted pages https://docusaurus.io/blog/releases/3.0#unlisted-content

I've used TypeScript for this, which builds fine with our current configuration, and can of course be switched to JS if needed.

Some items not in scope for this PR:
- VSCode is giving me a warning for wikilinks (link.no-such-reference)
- ~~Spaces are not replaced when checking/generating slugs in the page name resolver, we need a policy for filenames. (affects line 52, `slugReference`)~~
  - Assuming snake-case for doc (mdx) files, we should include some policy in the content guide.
- ~~Would be nice for the 404 page to include a link to create the page on github.~~ addressed already
- The page resolver already knows if a page does not exist, so the permalinks list is redundant, but changing this is probably not trivial.