### PR TITLE
Recommend VSCode MDX extension and configure for syntax highlighting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "files.autoSave": "off",
   "editor.insertSpaces": true,
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "mdx.server.enable": false
 }


### PR DESCRIPTION
We want to use wiki links, but those who use the VSCode [MDX](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) extension will see warnings for all of these, since they are not MDX syntax. (this extension is useful for mdx syntax highlighting).

This PR disables the experimental language server that the MDX extension enables by default. The MDX files will still be parsed by Docusaurus, so our testing (i.e. build step) should not be affected by this change.

The VSCode MDX extension can be configured to work with remark plugins (e.g. remark-wiki-link) but after some experimenting it does not seem trivial to do.