### PR TITLE
pluginContentDocsWrapper webpack cache fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-import pluginContentDocsWrapper from "./src/plugins/pluginContentDocsWrapper";
+import pluginContentDocsWrapper from "./src/plugins/pluginContentDocsWrapper.ts";
 
 const GITHUB_ORG = "comcode-org";
 const GITHUB_PROJECT = "hackmud_wiki";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,10 @@
   "extends": "@docusaurus/tsconfig/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    /**
-     * Fixes local lint error when importing JS files into TS modules (docusaurus already allows this.)
-     */
+    // Fixes local lint error when importing JS files into TS modules (docusaurus already allows this.)
     "allowJs": true,
-    /**
-     * Allows including an explicit file extension in an import, in case it is being inferred incorrectly.
-     * - Use this when webpack is warning about a caching error.
-     */
+    // Allows including an explicit file extension in an import, in case it is being inferred incorrectly.
+    // - Use this when webpack is warning about a caching error.
     "allowImportingTsExtensions": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "allowJs": true,
+    "allowImportingTsExtensions": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,14 @@
   "extends": "@docusaurus/tsconfig/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    /**
+     * Fixes local lint error when importing JS files into TS modules (docusaurus already allows this.)
+     */
     "allowJs": true,
+    /**
+     * Allows including an explicit file extension in an import, in case it is being inferred incorrectly.
+     * - Use this when webpack is warning about a caching error.
+     */
     "allowImportingTsExtensions": true
   }
 }


### PR DESCRIPTION
This PR adds the .ts extension to the wrapper plugin import in docusaurus config. The TS config has been modified to allow this. This fixes webpack failing to cache the module when building (throwing warnings in the console)

This works around the issue that imports are being inferred with incorrect filenames, and webpack is not trying other extensions if possible. The other fix is to change the docusaurus config to TS, which we may do, but this is a good experiment we can note for later in contributing.md, as that fix may not be possible for other files in the future.