### PR TITLE
Autocolor plugin

### DIFF
--- a/docs/autocolor_demo.mdx
+++ b/docs/autocolor_demo.mdx
@@ -1,0 +1,6 @@
+---
+title: Autocolor Demo
+unlisted: true
+---
+
+(( %X>>trust.me \{key: "value", key: \{}, key: #s.mallory.starchart, amount: "2B1KGC"}% ))

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,6 +5,22 @@ title: Home
 
 This is a home page.
 
+This is a colored regular paragraph: (( %X>>trust.me \{key: "value", key: \{}, key: #s.mallory.starchart, amount: "1KGC"}% )).
+
+This is unstyled: `trust.me`.
+
+This is manually styled in a manual code block:<code><span style={{ color: "yellow" }}>Yellow Text</span> + <span style={{color: "green"}}>Green Text</span></code>
+
+This is colored inline code: `(( %X>>trust.me {key: "value", key: {}, key: #s.mallory.starchart, amount: "1KGC"}% ))`
+
+This is colored inline code 2: `(( k:2 ))`
+
+This is a full code block:
+
+```javascript
+return { ok: true };
+```
+
 ## Section 1
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor ornare orci, vel gravida velit venenatis eget. Sed auctor, sem vitae consectetur egestas, tellus purus gravida nisl, et porta ipsum urna eu mauris. Morbi ultricies libero in iaculis eleifend. Nulla facilisi. Vivamus mattis tempus nisi, nec ultrices mauris tristique in. Nunc pulvinar aliquam lectus nec gravida. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In pellentesque massa et arcu auctor, porttitor ultrices dolor sagittis. Nulla pellentesque volutpat risus id congue.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,22 +5,6 @@ title: Home
 
 This is a home page.
 
-This is a colored regular paragraph: (( %X>>trust.me \{key: "value", key: \{}, key: #s.mallory.starchart, amount: "1KGC"}% )).
-
-This is unstyled: `trust.me`.
-
-This is manually styled in a manual code block:<code><span style={{ color: "yellow" }}>Yellow Text</span> + <span style={{color: "green"}}>Green Text</span></code>
-
-This is colored inline code: `(( %X>>trust.me {key: "value", key: {}, key: #s.mallory.starchart, amount: "1KGC"}% ))`
-
-This is colored inline code 2: `(( k:2 ))`
-
-This is a full code block:
-
-```javascript
-return { ok: true };
-```
-
 ## Section 1
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor ornare orci, vel gravida velit venenatis eget. Sed auctor, sem vitae consectetur egestas, tellus purus gravida nisl, et porta ipsum urna eu mauris. Morbi ultricies libero in iaculis eleifend. Nulla facilisi. Vivamus mattis tempus nisi, nec ultrices mauris tristique in. Nunc pulvinar aliquam lectus nec gravida. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In pellentesque massa et arcu auctor, porttitor ultrices dolor sagittis. Nulla pellentesque volutpat risus id congue.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 import pluginContentDocsWrapper from "./src/plugins/pluginContentDocsWrapper.ts";
+import autocolorPlugin from "./src/plugins/rehype/autocolor";
 
 const GITHUB_ORG = "comcode-org";
 const GITHUB_PROJECT = "hackmud_wiki";
@@ -43,7 +44,7 @@ const config = {
         // Plugins for remark, at the Markdown AST level
         remarkPlugins: [],
         // Plugins for rehype, at the HTML AST level
-        rehypePlugins: [],
+        rehypePlugins: [autocolorPlugin],
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "@docusaurus/theme-classic": "^3.0.1",
     "@mdx-js/react": "^3.0.0",
     "hast-util-find-and-replace": "^5.0.1",
-    "hast-util-from-html": "^2.0.1",
+    "hastscript": "^8.0.0",
     "react": "^18.2.0",
     "remark-wiki-link": "^2.0.1",
+    "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "hast-util-find-and-replace": "^5.0.1",
     "hast-util-from-html": "^2.0.1",
     "react": "^18.2.0",
-    "remark-wiki-link": "^2.0.1"
+    "remark-wiki-link": "^2.0.1",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@docusaurus/plugin-content-docs": "^3.0.1",
     "@docusaurus/theme-classic": "^3.0.1",
     "@mdx-js/react": "^3.0.0",
+    "hast-util-find-and-replace": "^5.0.1",
+    "hast-util-from-html": "^2.0.1",
     "react": "^18.2.0",
     "remark-wiki-link": "^2.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   remark-wiki-link:
     specifier: ^2.0.1
     version: 2.0.1
+  unist-builder:
+    specifier: ^4.0.0
+    version: 4.0.0
   unist-util-visit:
     specifier: ^5.0.0
     version: 5.0.0
@@ -4591,17 +4594,6 @@ packages:
       unist-util-visit-parents: 6.0.1
     dev: false
 
-  /hast-util-from-html@2.0.1:
-    resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
-    dependencies:
-      '@types/hast': 3.0.3
-      devlop: 1.1.0
-      hast-util-from-parse5: 8.0.1
-      parse5: 7.1.2
-      vfile: 6.0.1
-      vfile-message: 4.0.2
-    dev: false
-
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -8450,6 +8442,12 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       crypto-random-string: 4.0.0
+
+  /unist-builder@4.0.0:
+    resolution: {integrity: sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: false
 
   /unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   remark-wiki-link:
     specifier: ^2.0.1
     version: 2.0.1
+  unist-util-visit:
+    specifier: ^5.0.0
+    version: 5.0.0
 
 devDependencies:
   '@docusaurus/module-type-aliases':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ dependencies:
   '@mdx-js/react':
     specifier: ^3.0.0
     version: 3.0.0(@types/react@18.2.43)(react@18.2.0)
+  hast-util-find-and-replace:
+    specifier: ^5.0.1
+    version: 5.0.1
+  hastscript:
+    specifier: ^8.0.0
+    version: 8.0.0
   react:
     specifier: ^18.2.0
     version: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4579,6 +4579,26 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /hast-util-find-and-replace@5.0.1:
+    resolution: {integrity: sha512-S12fTskO3Hf2IGCBWXs1UcXT8GEJ3jmvmPZJctkRwfl3a8jnGi8aFYT8kd2zcEH+VE0qcGgKF0ewt5BPAsfIhw==}
+    dependencies:
+      '@types/hast': 3.0.3
+      escape-string-regexp: 5.0.0
+      hast-util-is-element: 3.0.0
+      unist-util-visit-parents: 6.0.1
+    dev: false
+
+  /hast-util-from-html@2.0.1:
+    resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
+    dependencies:
+      '@types/hast': 3.0.3
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.1
+      parse5: 7.1.2
+      vfile: 6.0.1
+      vfile-message: 4.0.2
+    dev: false
+
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -4590,6 +4610,12 @@ packages:
       vfile: 6.0.1
       vfile-location: 5.0.2
       web-namespaces: 2.0.1
+
+  /hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+    dependencies:
+      '@types/hast': 3.0.3
+    dev: false
 
   /hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -49,189 +49,189 @@ a.wikilink-new {
   color: #ff00ec;
 }
 
-.color-tag[tag="0"] {
+.color-tag[data-tag="0"] {
   color: #9b9b9b;
 }
-.color-tag[tag="1"] {
+.color-tag[data-tag="1"] {
   color: #ffffff;
 }
-.color-tag[tag="2"] {
+.color-tag[data-tag="2"] {
   color: #1eff00;
 }
-.color-tag[tag="3"] {
+.color-tag[data-tag="3"] {
   color: #0070dd;
 }
-.color-tag[tag="4"] {
+.color-tag[data-tag="4"] {
   color: #b035ee;
 }
-.color-tag[tag="5"] {
+.color-tag[data-tag="5"] {
   color: #ff8000;
 }
-.color-tag[tag="6"] {
+.color-tag[data-tag="6"] {
   color: #ff8000;
 }
-.color-tag[tag="7"] {
+.color-tag[data-tag="7"] {
   color: #ff8000;
 }
-.color-tag[tag="8"] {
+.color-tag[data-tag="8"] {
   color: #ff8000;
 }
-.color-tag[tag="9"] {
+.color-tag[data-tag="9"] {
   color: #ff8000;
 }
-.color-tag[tag="a"] {
+.color-tag[data-tag="a"] {
   color: #000000;
 }
-.color-tag[tag="b"] {
+.color-tag[data-tag="b"] {
   color: #3f3f3f;
 }
-.color-tag[tag="c"] {
+.color-tag[data-tag="c"] {
   color: #676767;
 }
-.color-tag[tag="d"] {
+.color-tag[data-tag="d"] {
   color: #7d0000;
 }
-.color-tag[tag="e"] {
+.color-tag[data-tag="e"] {
   color: #8e3434;
 }
-.color-tag[tag="f"] {
+.color-tag[data-tag="f"] {
   color: #a34f00;
 }
-.color-tag[tag="g"] {
+.color-tag[data-tag="g"] {
   color: #725437;
 }
-.color-tag[tag="h"] {
+.color-tag[data-tag="h"] {
   color: #a88600;
 }
-.color-tag[tag="i"] {
+.color-tag[data-tag="i"] {
   color: #b2934a;
 }
-.color-tag[tag="j"] {
+.color-tag[data-tag="j"] {
   color: #939500;
 }
-.color-tag[tag="k"] {
+.color-tag[data-tag="k"] {
   color: #495225;
 }
-.color-tag[tag="l"] {
+.color-tag[data-tag="l"] {
   color: #299400;
 }
-.color-tag[tag="m"] {
+.color-tag[data-tag="m"] {
   color: #23381b;
 }
-.color-tag[tag="n"] {
+.color-tag[data-tag="n"] {
   color: #00535b;
 }
-.color-tag[tag="o"] {
+.color-tag[data-tag="o"] {
   color: #324a4c;
 }
-.color-tag[tag="p"] {
+.color-tag[data-tag="p"] {
   color: #0073a6;
 }
-.color-tag[tag="q"] {
+.color-tag[data-tag="q"] {
   color: #385a6c;
 }
-.color-tag[tag="r"] {
+.color-tag[data-tag="r"] {
   color: #010067;
 }
-.color-tag[tag="s"] {
+.color-tag[data-tag="s"] {
   color: #507aa1;
 }
-.color-tag[tag="t"] {
+.color-tag[data-tag="t"] {
   color: #601c81;
 }
-.color-tag[tag="u"] {
+.color-tag[data-tag="u"] {
   color: #43314c;
 }
-.color-tag[tag="v"] {
+.color-tag[data-tag="v"] {
   color: #8c0069;
 }
-.color-tag[tag="w"] {
+.color-tag[data-tag="w"] {
   color: #973984;
 }
-.color-tag[tag="x"] {
+.color-tag[data-tag="x"] {
   color: #880024;
 }
-.color-tag[tag="y"] {
+.color-tag[data-tag="y"] {
   color: #762e4a;
 }
-.color-tag[tag="z"] {
+.color-tag[data-tag="z"] {
   color: #101215;
 }
-.color-tag[tag="A"] {
+.color-tag[data-tag="A"] {
   color: #ffffff;
 }
-.color-tag[tag="B"] {
+.color-tag[data-tag="B"] {
   color: #cacaca;
 }
-.color-tag[tag="C"] {
+.color-tag[data-tag="C"] {
   color: #9b9b9b;
 }
-.color-tag[tag="D"] {
+.color-tag[data-tag="D"] {
   color: #ff0000;
 }
-.color-tag[tag="E"] {
+.color-tag[data-tag="E"] {
   color: #ff8383;
 }
-.color-tag[tag="F"] {
+.color-tag[data-tag="F"] {
   color: #ff8000;
 }
-.color-tag[tag="G"] {
+.color-tag[data-tag="G"] {
   color: #f3aa6f;
 }
-.color-tag[tag="H"] {
+.color-tag[data-tag="H"] {
   color: #fbc803;
 }
-.color-tag[tag="I"] {
+.color-tag[data-tag="I"] {
   color: #ffd863;
 }
-.color-tag[tag="J"] {
+.color-tag[data-tag="J"] {
   color: #fff404;
 }
-.color-tag[tag="K"] {
+.color-tag[data-tag="K"] {
   color: #f3f998;
 }
-.color-tag[tag="L"] {
+.color-tag[data-tag="L"] {
   color: #1eff00;
 }
-.color-tag[tag="M"] {
+.color-tag[data-tag="M"] {
   color: #b3ff9b;
 }
-.color-tag[tag="N"] {
+.color-tag[data-tag="N"] {
   color: #00ffff;
 }
-.color-tag[tag="O"] {
+.color-tag[data-tag="O"] {
   color: #8fe6ff;
 }
-.color-tag[tag="P"] {
+.color-tag[data-tag="P"] {
   color: #0070dd;
 }
-.color-tag[tag="Q"] {
+.color-tag[data-tag="Q"] {
   color: #a4e3ff;
 }
-.color-tag[tag="R"] {
+.color-tag[data-tag="R"] {
   color: #0000ff;
 }
-.color-tag[tag="S"] {
+.color-tag[data-tag="S"] {
   color: #7ab2f4;
 }
-.color-tag[tag="T"] {
+.color-tag[data-tag="T"] {
   color: #b035ee;
 }
-.color-tag[tag="U"] {
+.color-tag[data-tag="U"] {
   color: #e6c4ff;
 }
-.color-tag[tag="V"] {
+.color-tag[data-tag="V"] {
   color: #ff00ec;
 }
-.color-tag[tag="W"] {
+.color-tag[data-tag="W"] {
   color: #ff96e0;
 }
-.color-tag[tag="X"] {
+.color-tag[data-tag="X"] {
   color: #ff0070;
 }
-.color-tag[tag="Y"] {
+.color-tag[data-tag="Y"] {
   color: #ff6a98;
 }
-.color-tag[tag="Z"] {
+.color-tag[data-tag="Z"] {
   color: #0c112b;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -5,3 +5,233 @@
 a.wikilink-new {
   color: var(--ifm-color-danger);
 }
+
+.color-trust {
+  color: #ff8000;
+}
+.color-user {
+  color: #9b9b9b;
+}
+.color-script {
+  color: #1eff00;
+}
+
+.color-cli {
+  color: #ffffff;
+}
+
+.color-gc-text {
+  color: #cacaca;
+}
+.color-gc-q {
+  color: #ff0000;
+}
+.color-gc-t {
+  color: #ff00ec;
+}
+.color-gc-b {
+  color: #fff404;
+}
+.color-gc-m {
+  color: #1eff00;
+}
+.color-gc-k {
+  color: #00ffff;
+}
+.color-gc-end {
+  color: #9b9b9b;
+}
+
+.color-key {
+  color: #00ffff;
+}
+.color-value {
+  color: #ff00ec;
+}
+
+.color-tag[tag="0"] {
+  color: #9b9b9b;
+}
+.color-tag[tag="1"] {
+  color: #ffffff;
+}
+.color-tag[tag="2"] {
+  color: #1eff00;
+}
+.color-tag[tag="3"] {
+  color: #0070dd;
+}
+.color-tag[tag="4"] {
+  color: #b035ee;
+}
+.color-tag[tag="5"] {
+  color: #ff8000;
+}
+.color-tag[tag="6"] {
+  color: #ff8000;
+}
+.color-tag[tag="7"] {
+  color: #ff8000;
+}
+.color-tag[tag="8"] {
+  color: #ff8000;
+}
+.color-tag[tag="9"] {
+  color: #ff8000;
+}
+.color-tag[tag="a"] {
+  color: #000000;
+}
+.color-tag[tag="b"] {
+  color: #3f3f3f;
+}
+.color-tag[tag="c"] {
+  color: #676767;
+}
+.color-tag[tag="d"] {
+  color: #7d0000;
+}
+.color-tag[tag="e"] {
+  color: #8e3434;
+}
+.color-tag[tag="f"] {
+  color: #a34f00;
+}
+.color-tag[tag="g"] {
+  color: #725437;
+}
+.color-tag[tag="h"] {
+  color: #a88600;
+}
+.color-tag[tag="i"] {
+  color: #b2934a;
+}
+.color-tag[tag="j"] {
+  color: #939500;
+}
+.color-tag[tag="k"] {
+  color: #495225;
+}
+.color-tag[tag="l"] {
+  color: #299400;
+}
+.color-tag[tag="m"] {
+  color: #23381b;
+}
+.color-tag[tag="n"] {
+  color: #00535b;
+}
+.color-tag[tag="o"] {
+  color: #324a4c;
+}
+.color-tag[tag="p"] {
+  color: #0073a6;
+}
+.color-tag[tag="q"] {
+  color: #385a6c;
+}
+.color-tag[tag="r"] {
+  color: #010067;
+}
+.color-tag[tag="s"] {
+  color: #507aa1;
+}
+.color-tag[tag="t"] {
+  color: #601c81;
+}
+.color-tag[tag="u"] {
+  color: #43314c;
+}
+.color-tag[tag="v"] {
+  color: #8c0069;
+}
+.color-tag[tag="w"] {
+  color: #973984;
+}
+.color-tag[tag="x"] {
+  color: #880024;
+}
+.color-tag[tag="y"] {
+  color: #762e4a;
+}
+.color-tag[tag="z"] {
+  color: #101215;
+}
+.color-tag[tag="A"] {
+  color: #ffffff;
+}
+.color-tag[tag="B"] {
+  color: #cacaca;
+}
+.color-tag[tag="C"] {
+  color: #9b9b9b;
+}
+.color-tag[tag="D"] {
+  color: #ff0000;
+}
+.color-tag[tag="E"] {
+  color: #ff8383;
+}
+.color-tag[tag="F"] {
+  color: #ff8000;
+}
+.color-tag[tag="G"] {
+  color: #f3aa6f;
+}
+.color-tag[tag="H"] {
+  color: #fbc803;
+}
+.color-tag[tag="I"] {
+  color: #ffd863;
+}
+.color-tag[tag="J"] {
+  color: #fff404;
+}
+.color-tag[tag="K"] {
+  color: #f3f998;
+}
+.color-tag[tag="L"] {
+  color: #1eff00;
+}
+.color-tag[tag="M"] {
+  color: #b3ff9b;
+}
+.color-tag[tag="N"] {
+  color: #00ffff;
+}
+.color-tag[tag="O"] {
+  color: #8fe6ff;
+}
+.color-tag[tag="P"] {
+  color: #0070dd;
+}
+.color-tag[tag="Q"] {
+  color: #a4e3ff;
+}
+.color-tag[tag="R"] {
+  color: #0000ff;
+}
+.color-tag[tag="S"] {
+  color: #7ab2f4;
+}
+.color-tag[tag="T"] {
+  color: #b035ee;
+}
+.color-tag[tag="U"] {
+  color: #e6c4ff;
+}
+.color-tag[tag="V"] {
+  color: #ff00ec;
+}
+.color-tag[tag="W"] {
+  color: #ff96e0;
+}
+.color-tag[tag="X"] {
+  color: #ff0070;
+}
+.color-tag[tag="Y"] {
+  color: #ff6a98;
+}
+.color-tag[tag="Z"] {
+  color: #0c112b;
+}

--- a/src/plugins/rehype/autocolor.js
+++ b/src/plugins/rehype/autocolor.js
@@ -1,5 +1,4 @@
 import { findAndReplace } from "hast-util-find-and-replace";
-import { visit } from "unist-util-visit";
 import { fromHtml } from "hast-util-from-html";
 
 const trustUsers = [
@@ -107,9 +106,7 @@ function colorAll(_fullMatch, content) {
 
 const autocolorPlugin = (_config) => {
   return (ast) => {
-    visit(ast, "text", (node, _index, parent) => {
-      findAndReplace(parent, [regexAutocolor, colorAll]);
-    });
+    findAndReplace(parent, [regexAutocolor, colorAll]);
   };
 };
 

--- a/src/plugins/rehype/autocolor.js
+++ b/src/plugins/rehype/autocolor.js
@@ -104,7 +104,7 @@ const autocolorPlugin = (_config) => {
     visit(ast, "text", (node, _index, parent) => {
       // Docusaurus forces <code> elements with HTML children into full-width code
       // blocks, which breaks the DOM tree. Disallow coloring in <code> for now.
-      if (regexAutocolor.test(node.value) && parent.tagName != "code") {
+      if (regexAutocolorBlock.test(node.value) && parent.tagName != "code") {
         const stubNode = {
           type: "root",
           children: [node],

--- a/src/plugins/rehype/autocolor.js
+++ b/src/plugins/rehype/autocolor.js
@@ -1,4 +1,5 @@
 import { findAndReplace } from "hast-util-find-and-replace";
+import { visit } from "unist-util-visit";
 import { fromHtml } from "hast-util-from-html";
 
 const trustUsers = [
@@ -106,7 +107,9 @@ function colorAll(_fullMatch, content) {
 
 const autocolorPlugin = (_config) => {
   return (ast) => {
-    findAndReplace(parent, [regexAutocolor, colorAll]);
+    visit(ast, "text", (node, _index, parent) => {
+      findAndReplace(parent, [regexAutocolor, colorAll]);
+    });
   };
 };
 

--- a/src/plugins/rehype/autocolor.js
+++ b/src/plugins/rehype/autocolor.js
@@ -1,0 +1,116 @@
+import { findAndReplace } from "hast-util-find-and-replace";
+import { visit } from "unist-util-visit";
+import { fromHtml } from "hast-util-from-html";
+
+const trustUsers = [
+  "accts",
+  "autos",
+  "binmat",
+  "chats",
+  "corps",
+  "escrow",
+  "gui",
+  "kernel",
+  "market",
+  "scripts",
+  "sys",
+  "trust",
+  "users",
+];
+
+// Matches (( <content > ))
+const regexAutocolor = /\(\((.*?)\)\)/g;
+
+// Matches <user>.<script> *except* when preceeded by a #
+// This is so that in #s.<user>.<script>, the s.<user> portion won't be colored
+const regexScript =
+  /\b(?<!#)([a-z_][a-z0-9_]{0,24})\.([a-z_][a-z0-9_]{0,24})\b/gi;
+
+// Matches ~<one character long color tag><content>~
+const regexColorTag = /%([0-9a-zA-z])(.+?)%/g;
+
+// Matches <key>: <value> with an arbitrary amount of spaces around the :
+// Key can either be a word like some_parameter:
+// or a quoted string like "this is multiple words":
+// Values can be strings, numbers, null, true, false, or scriptors
+// This will also match <key>: { or <key>: [ but will NOT include the { or [ in the match to be colorized
+const regexKvp =
+  /(\w+|".*?")[ ]*:[ ]*(?:(".*?"|\d+(?:\.\d*)?|null|true|false|#s\.\w+\.\w+)|(?=\{|\[))/g;
+
+// Matches GC strings, e.g. 1Q1T1B1M1K1GC
+// Explicitly does NOT match the text GC on its own
+// Notably, this only matches uppercase GC strings currently
+// This can be changed by adding an i to the regex flags, but lowercase strings will still be converted to uppercase when colorized
+const regexGC =
+  /(?=\d)(?:(\d+)Q)?(?:(\d{1,3})T)?(?:(\d{1,3})B)?(?:(\d{1,3})M)?(?:(\d{1,3})K)?(\d{1,3})?GC/g;
+
+function colorScript(_fullMatch, user, script) {
+  const isTrust = trustUsers.includes(user);
+  return (
+    `<span class="color-${isTrust ? "trust" : "user"}">${user}</span>` +
+    "." +
+    `<span class="color-script">${script}</span>`
+  );
+}
+
+function colorTag(_fullMatch, tag, inner) {
+  return `<span class="color-tag" tag="${tag}">${inner}</span>`;
+}
+
+function colorKvp(_fullMatch, key, value) {
+  if (!value) {
+    return `<span class="color-key">${key}</span>: `;
+  } else {
+    return `<span class="color-key">${key}</span>: <span class="color-value">${value}</span>`;
+  }
+}
+
+function colorGC(_fullMatch, q, t, b, m, k, units) {
+  const out = [];
+  const letters_and_values = [
+    ["q", q],
+    ["t", t],
+    ["b", b],
+    ["m", m],
+    ["k", k],
+  ];
+
+  for (const [letter, value] of letters_and_values) {
+    if (value) {
+      out.push(
+        `<span class="color-gc-text">${value}</span><span class="color-gc-${letter}">${letter.toUpperCase()}</span>`,
+      );
+    }
+  }
+  if (units) {
+    out.push(`<span class="color-gc-text">${units}</span>`);
+  }
+  out.push(`<span class="color-gc-end">GC</span>`);
+
+  return out.join("");
+}
+
+function colorAll(_fullMatch, content) {
+  const orig = content;
+  const passes = [
+    { regex: regexColorTag, replacer: colorTag },
+    { regex: regexKvp, replacer: colorKvp },
+    { regex: regexScript, replacer: colorScript },
+    { regex: regexGC, replacer: colorGC },
+  ];
+  for (const { regex, replacer } of passes) {
+    content = content.replace(regex, replacer);
+  }
+  const result = fromHtml(content, { fragment: true });
+  return result.children;
+}
+
+const autocolorPlugin = (_config) => {
+  return (ast) => {
+    visit(ast, "text", (node, _index, parent) => {
+      findAndReplace(parent, [regexAutocolor, colorAll]);
+    });
+  };
+};
+
+export default autocolorPlugin;


### PR DESCRIPTION
## Summary
Adds a `rehype` plugin to autocolor the following:
- `script.name` syntax
- key:value pairs
- GC strings
- Explicit color tags (similar to `` `Kblue` `` in-game)

There's an unlisted test page at `/autocolor_demo`.
![image](https://github.com/comcode-org/hackmud_wiki/assets/1775803/47543510-8e40-4689-acaf-435b997600e3)

## Special Syntax
Autocoloring will attempt to happen for all text wrapped in double parentheses `(( color.me ))`.
Explicit color tags use the `%` symbol, since `` ` `` is reserved for code blocks in markdown.

## Limitations (a.k.a. Opportunities for Future Development)
- This doesn't handle date strings.
- I have disabled autocoloring inside code blocks, as some post-processing Docusaurus does causes this to break the DOM. Will add more detail in a separate issue.
- The code isn't testable, probably want to refactor the regexes and maybe some supporting functions into a separate file.