### PR TITLE
break out some tests so easier to see failures

### DIFF
--- a/docs/autocolor_demo.mdx
+++ b/docs/autocolor_demo.mdx
@@ -3,4 +3,22 @@ title: Autocolor Demo
 unlisted: true
 ---
 
+### simple
+
+(( scripts.trust ))
+
+### color
+
+(( %5foo% ))
+
+### key-value
+
+(( key: "value" ))
+
+### GC
+
+(( 2Q45T251B1K5GC ))
+
+### complex
+
 (( %X>>trust.me \{key: "value", key: \{}, key: #s.mallory.starchart, amount: "2B1KGC"}% ))


### PR DESCRIPTION
### problem

If someone looks at the autocolor test page, they may miss things that need to be colored in the complex test

### context

this adds some additional coverage for GC and %5% as well.