### PR TITLE
restrict jest test match glob

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ This document builds on the [default contributing.md](https://github.com/comcode
 
 ### Creating tests
 
-1. For some module `foo.ts`, create a file `foo.test.ts` in the same directory. (Must be within /src)
+1. For some module `foo.ts`, create a file `foo.test.ts` in the same directory.
+   - Tests must be within `/src`.
+   - `.tsx` `.mjs` `.jsx` and `.js` are also valid extensions.
 2. Import required jest utils from `@jest/globals`, and the module to be tested.
 3. Use `describe` to log what code is being tested and use `it` to describe a specification of the module.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,24 +10,6 @@ This document builds on the [default contributing.md](https://github.com/comcode
 
 ### Creating tests
 
-1. For some module `foo.ts`, create a file `foo.test.ts` in the same directory.
-   - Tests must be within `/src`.
-   - `.tsx` `.mjs` `.jsx` and `.js` are also valid extensions.
-2. Import required jest utils from `@jest/globals`, and the module to be tested.
-3. Use `describe` to log what code is being tested and use `it` to describe a specification of the module.
-
-```ts
-/** @file criticalMathModule.test.ts */
-import { describe, expect, it } from "@jest/globals";
-import { isEven } from "./criticalMathModule";
-
-describe("criticalMathModule", () => {
-  // read as: it checks if numbers are even
-  it("checks if numbers are even", () => {
-    expect(isEven(1)).toBe(false);
-    expect(isEven(4)).toBe(true);
-  });
-});
-```
+Test files must be within `/src`, with a file name ending in `.test.<ext>`, where `<ext>` is one of `js` `mjs` `jsx` `ts` `tsx`.
 
 ## How to review a code change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This document builds on the [default contributing.md](https://github.com/comcode
 3. Use `describe` to log what code is being tested and use `it` to describe a specification of the module.
 
 ```ts
-/** @file {criticalMathModule.ts} */
+/** @file criticalMathModule.test.ts */
 import { describe, expect, it } from "@jest/globals";
 import { isEven } from "./criticalMathModule";
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,24 @@ This document builds on the [default contributing.md](https://github.com/comcode
 
 ## How to make changes to code
 
+### Creating tests
+
+1. For some module `foo.ts`, create a file `foo.test.ts` in the same directory. (Must be within /src)
+2. Import required jest utils from `@jest/globals`, and the module to be tested.
+3. Use `describe` to log what code is being tested and use `it` to describe a specification of the module.
+
+```ts
+/** @file {criticalMathModule.ts} */
+import { describe, expect, it } from "@jest/globals";
+import { isEven } from "./criticalMathModule";
+
+describe("criticalMathModule", () => {
+  // read as: it checks if numbers are even
+  it("checks if numbers are even", () => {
+    expect(isEven(1)).toBe(false);
+    expect(isEven(4)).toBe(true);
+  });
+});
+```
+
 ## How to review a code change

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,6 @@
 module.exports = {
   preset: "ts-jest/presets/js-with-ts-esm",
   testEnvironment: "node",
-  testMatch: [
-    "**/__tests__/**/*.{[jt]s?(x),mjs}",
-    "**/*(*.)+(spec|test).{[jt]s?(x),mjs}",
-  ],
+  // tests must be within /src, with .spec or .test before file extension
+  testMatch: ["<rootDir>/src/**/*(*.)+(spec|test).{[jt]s?(x),mjs}"],
 };


### PR DESCRIPTION
restricts jest to only look in /src for test files, and removes match for files that don't have .test or .spec, e.g. `__tests__/foo.ts`

also adds docs