### PR TITLE
Move c003 'solutions' header to level 2

### DIFF
--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -4,7 +4,7 @@ title: c003
 
 c003 is one of the very first locks you'll run into in hackmud.
 
-# Solutions
+## Solutions
 
 <details>
 <summary>Spoilers for c003's solutions</summary>


### PR DESCRIPTION
Fixes the auto-generated title not appearing.
Also complies with the style guide now.