### PR TITLE
Refactor lock template

### DIFF
--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -4,7 +4,7 @@ title: lock template
 
 > In-game description of the lock, typically from sys.upgrades \{ full: true }
 
-<lock> is a tier <N> lock {created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
+<lock> is a tier <N> lock \{created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
 
 ## Stats
 

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -4,7 +4,7 @@ title: lock template
 
 > In-game description of the lock, typically from sys.upgrades \{ full: true }
 
-<lock> is a tier <N> lock \{created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
+_lock_ is a tier _N_ lock \{created by the _in-game corp_ corporation | exclude if the lock does not announce its manufacturer}.
 
 ## Stats
 
@@ -23,20 +23,41 @@ Success: True
 
 ## Solving
 
-<details>
-<summary>Spoilers for lock's solutions</summary>
-
-The arguments required for solving
-
-### Subheaders that describe individual arguments
-
-Spoilery description of each argument. Maybe a table of answers, maybe how a value is found.
-
-</details>
-
-## Example unlock
+### Example unlock
 
 <details>
   <summary>Spoilers for lock's solutions</summary>
-  ``` An example potential solution, outputted from the CLI ```
+
+```
+>>user.fakeloc123 {}
+An example potential solution, outputted from the CLI, with its success output
+```
+
+</details>
+
+### Subheader for argument 1 (eg. ez_40)
+
+<details>
+<summary>Spoilers</summary>
+
+Value solutions for the specific argument key. Maybe a table of answers, maybe how a value is found.
+
+</details>
+
+### Subheader for argument 2 (eg. ez_prime)
+
+<details>
+<summary>Spoilers</summary>
+
+Value solutions for the specific argument key. Maybe a table of answers, maybe how a value is found.
+
+</details>
+
+### Subheader for specific additional solving topic
+
+<details>
+<summary>Spoilers</summary>
+
+Spoilery description of an additional solution topic. Maybe how arguments are matched to one another, like c002 & c003. Might be a table of answers or how a value is found.
+
 </details>

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -2,11 +2,11 @@
 title: lock template
 ---
 
-## Description
+> In-game description of the lock, typically from sys.upgrades { full: true }
 
-In-game description of the lock, typically from sys.upgrades { full: true }
+<lock> is a tier <N> lock {created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
 
-### Subheader for stats
+### Stats
 
 stats?
 
@@ -23,12 +23,20 @@ Success: True
 
 ## Solving
 
+<details>
+<summary>Spoilers for lock's solutions</summary>
 The arguments required for solving
 
 ### Subheaders that describe individual arguments
 
 Spoilery description of each argument. Maybe a table of answers, maybe how a value is found.
+</details>
 
 ## Example unlock
 
-An example potentional solution written out for the cli
+<details>
+<summary>Spoilers for lock's solutions</summary>
+```
+An example potential solution, outputted from the CLI
+```
+</details>

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -6,7 +6,7 @@ title: lock template
 
 <lock> is a tier <N> lock {created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
 
-### Stats
+## Stats
 
 Unique stats that are included in the lock's statistics. Include the range of rarities that the lock spawns at.
 

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -2,7 +2,7 @@
 title: lock template
 ---
 
-> In-game description of the lock, typically from sys.upgrades { full: true }
+> In-game description of the lock, typically from sys.upgrades \{ full: true }
 
 <lock> is a tier <N> lock {created by the <in-game corp> corporation | exclude if the lock does not announce its manufacturer}.
 

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -30,13 +30,12 @@ The arguments required for solving
 ### Subheaders that describe individual arguments
 
 Spoilery description of each argument. Maybe a table of answers, maybe how a value is found.
+
 </details>
 
 ## Example unlock
 
 <details>
-<summary>Spoilers for lock's solutions</summary>
-```
-An example potential solution, outputted from the CLI
-```
+  <summary>Spoilers for lock's solutions</summary>
+  ``` An example potential solution, outputted from the CLI ```
 </details>

--- a/templates/lock.mdx
+++ b/templates/lock.mdx
@@ -8,7 +8,7 @@ title: lock template
 
 ### Stats
 
-stats?
+Unique stats that are included in the lock's statistics. Include the range of rarities that the lock spawns at.
 
 ## Behavior
 


### PR DESCRIPTION
This PR refactors the lock template to conform to the content guide and the general direction we're going with on lock pages:

- Places the description in a quote at the start of the article (so that an "informative" quote appears in the autogenerated category)
  - ![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/53e35b60-256c-4fff-8d6b-de750600631f)
- Adds spoiler tag templates
- Adds a starting blurb that explains the lock's tier and manufacturer