### PR TITLE
fix formatting for template: documentation.mdx

### DIFF
--- a/templates/documentation.mdx
+++ b/templates/documentation.mdx
@@ -2,9 +2,7 @@
 title: documentation template
 ---
 
-## Description
-
-In-game description of the script or function
+> In-game description of the script or function
 
 ### Security Level
 


### PR DESCRIPTION
fixes #46 

### Problem
Having the 'Description' header hides the content from the auto generated page.