### PR TITLE
fixing various formatting errors and typos

### DIFF
--- a/docs/scripting/trust_scripts/accts.balance.mdx
+++ b/docs/scripting/trust_scripts/accts.balance.mdx
@@ -53,5 +53,4 @@ function(context, args)
 	let bal = #hs.accts.balance()
 	return bal
 }
-
 ```

--- a/docs/scripting/trust_scripts/accts.transactions.mdx
+++ b/docs/scripting/trust_scripts/accts.transactions.mdx
@@ -95,10 +95,9 @@ Using the same transaction log from above:
 ```
 function(context, args)
 {
-	let transactions = #hs.accts.transactions({count:4,from:"trust"})
+	let transactions = #hs.accts.transactions({ count: 4, from: "trust" })
 	return transactions
 }
-
 ```
 
 Since we have specified that we would like our return to include transactions from trust out of a list of 4 total transactions, this example would filter our list down to the following:

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -19,7 +19,7 @@ accts.xfer_gc_to_caller
 ### Script
 
 ```
-#fs.accts.xfer_gc_to_caller({ amount:"1M234K567GC", memo:"this is a memo" })
+#fs.accts.xfer_gc_to_caller({ amount: "1M234K567GC", memo: "this is a memo" })
 ```
 
 ### Parameters

--- a/docs/scripting/trust_scripts/autos.reset.mdx
+++ b/docs/scripting/trust_scripts/autos.reset.mdx
@@ -2,7 +2,7 @@
 title: autos.reset
 ---
 
-autos.reset clears out all of a users autocompletes.
+autos.reset clears out all of a user's autocompletes.
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/autos.reset.mdx
+++ b/docs/scripting/trust_scripts/autos.reset.mdx
@@ -2,7 +2,7 @@
 title: autos.reset
 ---
 
-autos.reset clears out all of a users autocompletes
+autos.reset clears out all of a users autocompletes.
 
 ### Security level
 
@@ -47,5 +47,4 @@ function(context, args)
 {
 	return #ms.autos.reset()
 }
-
 ```

--- a/docs/scripting/trust_scripts/chats.channels.mdx
+++ b/docs/scripting/trust_scripts/chats.channels.mdx
@@ -50,5 +50,4 @@ function(context, args)
 {
 	return #ms.chats.channels()
 }
-
 ```

--- a/docs/scripting/trust_scripts/chats.create.mdx
+++ b/docs/scripting/trust_scripts/chats.create.mdx
@@ -19,7 +19,7 @@ chats.create { name: "example_channel", password: "examplepass" }
 ### Script
 
 ```
-#fs.chats.create({ name:"example_channel", password:"examplepass" })
+#fs.chats.create({ name: "example_channel", password: "examplepass" })
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ Returns an object.
 #### CLI
 
 ```
->>chats.create { name:"example_channel" }
+>>chats.create { name: "example_channel" }
 Success
 
 1555 example_channel <user> :::user joined channel:::

--- a/docs/scripting/trust_scripts/chats.join.mdx
+++ b/docs/scripting/trust_scripts/chats.join.mdx
@@ -13,13 +13,13 @@ MIDSEC
 ### CLI
 
 ```
-chats.join { channel:"example_channel" }
+chats.join { channel: "example_channel" }
 ```
 
 ### Script
 
 ```
-#ms.chats.join({ channel:"example_channel" })
+#ms.chats.join({ channel: "example_channel" })
 ```
 
 ### Parameters
@@ -52,5 +52,4 @@ function(context, args)
 {
 	return #ms.chats.join({ channel: "example_channel" })
 }
-
 ```

--- a/docs/scripting/trust_scripts/chats.leave.mdx
+++ b/docs/scripting/trust_scripts/chats.leave.mdx
@@ -35,7 +35,7 @@ Returns an object.
 #### CLI
 
 ```
->>chats.leave {channel:"example_channel"}
+>>chats.leave {channel: "example_channel"}
 Success
 
 1613 example_channel <user> :::user left channel:::
@@ -52,5 +52,4 @@ function(context, args)
 {
 	return #ms.chats.leave({ channel: "example_channel" })
 }
-
 ```

--- a/docs/scripting/trust_scripts/chats.send.mdx
+++ b/docs/scripting/trust_scripts/chats.send.mdx
@@ -39,7 +39,7 @@ Returns an object.
 #### CLI
 
 ```
->>chats.send { channel:"example_channel", msg:"this is a message" }
+>>chats.send { channel: "example_channel", msg: "this is a message" }
 Msg Sent
 
 1621 example_channel kbeeb :::this is a message:::

--- a/docs/scripting/trust_scripts/chats.tell.mdx
+++ b/docs/scripting/trust_scripts/chats.tell.mdx
@@ -19,7 +19,7 @@ chats.tell { to: "user", msg: "this is a private message" }
 ### Script
 
 ```
-#fs.chats.tell({ to: "user", msg : "this is a private message" })
+#fs.chats.tell({ to: "user", msg: "this is a private message" })
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ Returns an object.
 #### CLI
 
 ```
->>chats.tell { to:"user", msg:"this is a private message" }
+>>chats.tell { to: "user", msg: "this is a private message" }
 Msg Sent
 
 1555 to user :::this is a private message:::
@@ -56,5 +56,4 @@ function(context, args)
 {
 	return #ms.chats.tell({ to: "user", msg: "this is a private message" })
 }
-
 ```

--- a/docs/scripting/trust_scripts/chats.users.mdx
+++ b/docs/scripting/trust_scripts/chats.users.mdx
@@ -35,7 +35,7 @@ Returns an array.
 #### CLI
 
 ```
->>chats.users { channel:"example_channel" }
+>>chats.users { channel: "example_channel" }
 *<user>
 *trust
 inactive_user_123
@@ -52,5 +52,4 @@ function(context, args)
 {
 	return #ms.chats.users({ channel: "example_channel" })
 }
-
 ```

--- a/docs/scripting/trust_scripts/corps.create.mdx
+++ b/docs/scripting/trust_scripts/corps.create.mdx
@@ -56,5 +56,4 @@ function(context, args)
 {
 	return #ns.corps.create({ name: "example_corp", confirm: true })
 }
-
 ```

--- a/docs/scripting/trust_scripts/corps.hire.mdx
+++ b/docs/scripting/trust_scripts/corps.hire.mdx
@@ -13,7 +13,7 @@ NULLSEC
 ### CLI
 
 ```
-corps.hire { name:"example_user" }
+corps.hire { name: "example_user" }
 ```
 
 ### Script
@@ -35,7 +35,7 @@ Returns an object.
 #### CLI
 
 ```
->>corps.hire{name:"example_user"}
+>>corps.hire{name: "example_user"}
 Success
 
 ```

--- a/docs/scripting/trust_scripts/corps.manage.mdx
+++ b/docs/scripting/trust_scripts/corps.manage.mdx
@@ -13,13 +13,13 @@ NULLSEC
 ### CLI
 
 ```
-corps.manage { command: "<choice>" }
+corps.manage { command: "list" }
 ```
 
 ### Script
 
 ```
-#ns.corps.manage({ command: "<choice>" })
+#ns.corps.manage({ command: "list" })
 ```
 
 ### Parameters

--- a/docs/scripting/trust_scripts/corps.offers.mdx
+++ b/docs/scripting/trust_scripts/corps.offers.mdx
@@ -82,5 +82,4 @@ function(context, args)
 		return "No current offers"
 	}
 }
-
 ```

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -13,13 +13,13 @@ FULLSEC
 ### CLI
 
 ```
-escrow.charge { cost:"1GC", is_unlim: true }
+escrow.charge { cost: "1GC", is_unlim: true }
 ```
 
 ### Script
 
 ```
-#fs.escrow.charge({ cost:"1GC", is_unlim : true })
+#fs.escrow.charge({ cost: "1GC", is_unlim : true })
 ```
 
 ### Parameters

--- a/docs/scripting/trust_scripts/gui.chats.mdx
+++ b/docs/scripting/trust_scripts/gui.chats.mdx
@@ -13,7 +13,7 @@ FULLSEC
 ### CLI
 
 ```
->>gui.chats { shell:false, chat:true }
+>>gui.chats { shell: false, chat: true }
 Success
 ```
 
@@ -40,7 +40,7 @@ Returns a Success or Failure object.
 #### CLI
 
 ```
->>gui.chats { shell:true, chat:true }
+>>gui.chats { shell: true, chat: true }
 Success
 ```
 

--- a/docs/scripting/trust_scripts/gui.quiet.mdx
+++ b/docs/scripting/trust_scripts/gui.quiet.mdx
@@ -47,7 +47,7 @@ Returns a Success or Failure object.
 #### CLI
 
 ```
->>gui.quiet { clear:true }
+>>gui.quiet { clear: true }
 Success
 quiet list has been cleared
 ```

--- a/docs/scripting/trust_scripts/gui.vfx.mdx
+++ b/docs/scripting/trust_scripts/gui.vfx.mdx
@@ -13,7 +13,7 @@ FULLSEC
 ### CLI
 
 ```
-gui.vfx { bloom:0, noise:0, scan:0, bend:0 }
+gui.vfx { bloom: 0, noise: 0, scan: 0, bend: 0 }
 ```
 
 ### Script

--- a/docs/scripting/trust_scripts/gui.vol.mdx
+++ b/docs/scripting/trust_scripts/gui.vol.mdx
@@ -39,7 +39,7 @@ Returns a Success or Failure object.
 #### CLI
 
 ```
->>gui.vol { bgm:5, sfx:5 }
+>>gui.vol { bgm: 5, sfx: 5 }
 Success
 ```
 

--- a/docs/scripting/trust_scripts/kernel.hardline.mdx
+++ b/docs/scripting/trust_scripts/kernel.hardline.mdx
@@ -18,7 +18,7 @@ kernel.hardline
 
 ### Script
 
-Note: kernel.hardline can only be called as a subscript by bot_brains.
+Note: kernel.hardline can only be called as a subscript by [[bot_brains]].
 
 ```
 #ls.kernel.hardline({ activate: true })
@@ -32,7 +32,7 @@ The 'dc' argument disconnects from hardline mode when its value is set to true.
 
 #### activate
 
-The 'activate' argument is required for bot_brains to hardline.
+The 'activate' argument is required for [[bot_brains]] to hardline.
 
 ### Return
 
@@ -47,7 +47,7 @@ Returns a Success or Failure object.
 
 #### Script
 
-Can only be called as a subscript by bot_brains.
+Can only be called as a subscript by [[bot_brains]].
 
 ## Example
 

--- a/docs/scripting/trust_scripts/market.buy.mdx
+++ b/docs/scripting/trust_scripts/market.buy.mdx
@@ -15,13 +15,13 @@ market.buy takes a market token as a string and requires that the value of the '
 ### CLI
 
 ```
-market.buy { i: ""}
+market.buy { i: "token5" }
 ```
 
 ### Script
 
 ```
-#ms.market.buy({ i:"ebwff5", confirm: true })
+#ms.market.buy({ i: "ebwff5", confirm: true })
 ```
 
 ### Parameters

--- a/docs/scripting/trust_scripts/scripts.get_access_level.mdx
+++ b/docs/scripting/trust_scripts/scripts.get_access_level.mdx
@@ -42,7 +42,7 @@ The 'name' argument specifies which scripts' access level shall be checked.
 On the CLI scripts.get_access_level returns a string.
 
 ```
->>scripts.get_access_level { name:"accts.balance" }
+>>scripts.get_access_level { name: "accts.balance" }
 PUBLIC TRUST
 ```
 

--- a/docs/scripting/trust_scripts/scripts.highsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.highsec.mdx
@@ -2,11 +2,11 @@
 title: scripts.highsec
 ---
 
-scripts.highsec lists the highsec sectors.
+scripts.highsec lists the HIGHSEC sectors.
 
 ### Security Level
 
-highsec
+HIGHSEC
 
 ## Syntax
 
@@ -26,7 +26,7 @@ scripts.highsec
 
 #### sector
 
-The 'sector' argument specifies the highsec sector to be shown.
+The 'sector' argument specifies the HIGHSEC sector to be shown.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/scripts.lowsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.lowsec.mdx
@@ -2,7 +2,7 @@
 title: scripts.lowsec
 ---
 
-scripts.lowsec lists the lowsec sectors.
+scripts.lowsec lists the LOWSEC sectors.
 
 ### Security Level
 
@@ -26,7 +26,7 @@ scripts.lowsec
 
 #### sector
 
-The 'sector' argument specifies the lowsec sector to be shown.
+The 'sector' argument specifies the LOWSEC sector to be shown.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/scripts.midsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.midsec.mdx
@@ -2,7 +2,7 @@
 title: scripts.midsec
 ---
 
-scripts.midsec lists the midsec sectors.
+scripts.midsec lists the MIDSEC sectors.
 
 ### Security Level
 
@@ -26,7 +26,7 @@ scripts.midsec
 
 #### sector
 
-The 'sector' argument specifies the midsec sector to be shown.
+The 'sector' argument specifies the MIDSEC sector to be shown.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/scripts.nullsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.nullsec.mdx
@@ -2,7 +2,7 @@
 title: scripts.nullsec
 ---
 
-scripts.nullsec lists the nullsec sectors.
+scripts.nullsec lists the NULLSEC sectors.
 
 ### Security Level
 
@@ -26,7 +26,7 @@ scripts.nullsec
 
 #### sector
 
-The 'sector' argument specifies the nullsec sector to be shown.
+The 'sector' argument specifies the NULLSEC sector to be shown.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/scripts.user.mdx
+++ b/docs/scripting/trust_scripts/scripts.user.mdx
@@ -32,7 +32,7 @@ Returns an array.
 
 #### CLI
 
-On the CLI, the array of script names will be formatted in 2 columns.
+On the CLI, the array of script names will be formatted in 4 columns.
 
 ```
 users.example_script_1 users.example_script_2

--- a/docs/scripting/trust_scripts/sys.access_log.mdx
+++ b/docs/scripting/trust_scripts/sys.access_log.mdx
@@ -2,7 +2,7 @@
 title: sys.access_log
 ---
 
-> sys.access_log displays information about connection attempts from other systems, including lock state and breach state rotation.
+sys.access_log displays information about connection attempts from other systems, including lock state and breach state rotation.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/sys.breach.mdx
+++ b/docs/scripting/trust_scripts/sys.breach.mdx
@@ -38,14 +38,14 @@ No parameters or invalid parameters:
 
 ```
 >>sys.breach
-Usage: sys.breach {confirm: true}
+Usage: sys.breach { confirm: true }
 breaches sys
 ```
 
 With confirm parameter:
 
 ```
->>sys.breach{confirm:true}
+>>sys.breach{ confirm: true }
 Success
 
 System has been breached.
@@ -54,7 +54,7 @@ System has been breached.
 On uninitialized system:
 
 ```
->>sys.breach{confirm:true}
+>>sys.breach{ confirm: true }
 Failure
 sys not initialized
 ```

--- a/docs/scripting/trust_scripts/sys.init.mdx
+++ b/docs/scripting/trust_scripts/sys.init.mdx
@@ -40,7 +40,7 @@ No parameters or invalid parameters:
 >>sys.init
 Initializing a system costs 1MGC. Once your system is initialized, it can be upgraded.
 Tier 1 systems can hold 20MGC.
-To initialize your system use {confirm: true}
+To initialize your system use { confirm: true }
 ```
 
 Correct parameters:

--- a/docs/scripting/trust_scripts/sys.specs.mdx
+++ b/docs/scripting/trust_scripts/sys.specs.mdx
@@ -57,4 +57,4 @@ chars: <current character limit>
 
 #### Script
 
-Same as CLI
+Same as CLI.

--- a/docs/scripting/trust_scripts/sys.upgrade_log.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrade_log.mdx
@@ -2,7 +2,7 @@
 title: sys.upgrade_log
 ---
 
-> sys.upgrade_log displays information about upgrades which have been sent and recieved.
+sys.upgrade_log displays information about upgrades which have been sent and recieved.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/sys.upgrades.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrades.mdx
@@ -2,7 +2,7 @@
 title: sys.upgrades
 ---
 
-> sys.upgrades displays information about the upgrades present on the system.
+sys.upgrades displays information about the upgrades present on the system.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/users.active.mdx
+++ b/docs/scripting/trust_scripts/users.active.mdx
@@ -49,6 +49,6 @@ current users: 293
 ```
 function(context, args)
 {
-	return typeof(#fs.users.active())
+	return #fs.users.active()
 }
 ```


### PR DESCRIPTION
Fixes:
- Indendation was set to 8
- Trailing whitespace after script example
- Various spacing errors, typos etc.
- User input and script output fixes