### PR TITLE
add alias for start: `dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "CC-BY-NC-SA-4.0",
   "private": true,
   "scripts": {
+    "dev": "pnpm start",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "test": "jest",


### PR DESCRIPTION
### problem

The comcode.org repo uses `dev` and this repo uses `start`, let's make it less hard to remember which one by adding an alias