### PR TITLE
Add section on italics to style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ function(context,args){
 
 1.  Articles should be written using American English.
 
-#### Name Conventions
+#### Capitialization
 
 1. When referring to upgrades do not capitalize them as proper nouns.
-1. The name hackmud is always lowercase and italic.
+1. The name hackmud is always lowercase.
 1. Even at the start of a sentence, a word or upgrade that should be lowercase is still lowercase.
 
 #### Disambiguating Parameters, Args, Key:Value Pairs
@@ -118,6 +118,11 @@ function(context,args){
 1. Exceptions to heading capitalization are upgrades, corporations, and entities. Those should follow in-game styling and capitalization.
 1. If a section of an article is empty or needs information filled in, the pull request should be created as a draft with a comment requesting the help needed.
 1. Headings should never contain links.
+
+### Italicization
+
+1. Any instance of the name of a video game should be in italics. For instance: "_hackmud_"
+2. Only official edition names should be italicized. For instance: "_hackmud_" or "_binmat_".
 
 ### Linking
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ function(context,args){
 
 1.  Articles should be written using American English.
 
-#### Capitialization
+#### Capitalization
 
 1. When referring to upgrades do not capitalize them as proper nouns.
 1. The name hackmud is always lowercase.
@@ -122,7 +122,7 @@ function(context,args){
 ### Italicization
 
 1. Any instance of the name of a video game should be in italics. For instance: "_hackmud_"
-2. Only official edition names should be italicized. For instance: "_hackmud_" or "_binmat_".
+1. Only official edition names should be italicized. For instance: "_hackmud_" or "_binmat_".
 
 ### Linking
 


### PR DESCRIPTION
Reverts renaming of capitalization header and adds italicization header in readme.md for rules regarding italics.

The second rule is not really needed and am open for removing as we don't really have multiple versions for the game. However, it is worth noting that under this, binmat should be italicized.

[Here](https://minecraft.fandom.com/wiki/Minecraft_Wiki:Style_guide#Italics) is a reference style guide about a similar topic.