### PR TITLE
Correct incorrectly-attributed seclevels for trust script examples

### DIFF
--- a/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
@@ -58,6 +58,6 @@ Caution: While this is a legitimately useful script, it will send the specified 
 ```
 function(context, args)
 {
-	return #ms.accts.xfer_gc_to ({ to: "trust", amount: "1GC", memo: "here's that 1GC i promised you." })
+	return #ms.accts.xfer_gc_to({ to: "trust", amount: "1GC", memo: "here's that 1GC i promised you." })
 }
 ```

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -46,7 +46,7 @@ Usage: (in subscript) #fs.accts.xfer_gc_to_caller({ amount:<number or "GC string
 ```
 Success
 
-Transferred 1GC to trust
+Received 1GC from user
 ```
 
 ## Example
@@ -54,7 +54,7 @@ Transferred 1GC to trust
 ```
 function(context, args)
 {
-	return #ms.accts.xfer_gc_to({ to: "trust", amount: "1GC", memo: "this is a memo" })
+	return #fs.accts.xfer_gc_to_caller({ amount: "1GC", memo: "this is a memo" })
 }
 
 ```

--- a/docs/scripting/trust_scripts/chats.send.mdx
+++ b/docs/scripting/trust_scripts/chats.send.mdx
@@ -54,7 +54,7 @@ Same as CLI.
 ```
 function(context, args)
 {
-	return #ms.chats.send({ channel: "example_channel", msg: "this is a message" })
+	return #fs.chats.send({ channel: "example_channel", msg: "this is a message" })
 }
 
 ```

--- a/docs/scripting/trust_scripts/chats.tell.mdx
+++ b/docs/scripting/trust_scripts/chats.tell.mdx
@@ -54,6 +54,6 @@ Same as CLI.
 ```
 function(context, args)
 {
-	return #ms.chats.tell({ to: "user", msg: "this is a private message" })
+	return #fs.chats.tell({ to: "user", msg: "this is a private message" })
 }
 ```

--- a/docs/scripting/trust_scripts/corps.top.mdx
+++ b/docs/scripting/trust_scripts/corps.top.mdx
@@ -154,6 +154,6 @@ Return an object.
 ```
 function (context, args)
 {
-  return #fs.corps.top()
+  return #ns.corps.top()
 }
 ```

--- a/docs/scripting/trust_scripts/sys.init.mdx
+++ b/docs/scripting/trust_scripts/sys.init.mdx
@@ -54,13 +54,4 @@ Transferred 1MGC to trust
 
 #### Script
 
-Same as CLI.
-
-## Example
-
-```
-function(context, args)
-{
-	return #ns.sys.init({ confirm: true })
-}
-```
+Cannot be called as a subscript.

--- a/docs/scripting/trust_scripts/sys.loc.mdx
+++ b/docs/scripting/trust_scripts/sys.loc.mdx
@@ -46,6 +46,6 @@ Same as CLI.
 ```
 function(context, args)
 {
-	return #ns.sys.loc()
+	return #ls.sys.loc()
 }
 ```

--- a/docs/scripting/trust_scripts/sys.specs.mdx
+++ b/docs/scripting/trust_scripts/sys.specs.mdx
@@ -58,3 +58,12 @@ chars: <current character limit>
 #### Script
 
 Same as CLI.
+
+## Example
+
+```
+function(context, args)
+{
+	return #hs.sys.specs()
+}
+```

--- a/docs/scripting/trust_scripts/sys.status.mdx
+++ b/docs/scripting/trust_scripts/sys.status.mdx
@@ -53,3 +53,15 @@ or
   breach: false
 }
 ```
+
+## Example
+
+```
+function(context, args)
+{
+	let myStatus = #hs.sys.status()
+
+  if(myStatus.breach) return "WE ARE BREACHED"
+  else return "we are not breached!"
+}
+```

--- a/docs/scripting/trust_scripts/sys.status.mdx
+++ b/docs/scripting/trust_scripts/sys.status.mdx
@@ -59,9 +59,6 @@ or
 ```
 function(context, args)
 {
-	let myStatus = #hs.sys.status()
-
-  if(myStatus.breach) return "WE ARE BREACHED"
-  else return "we are not breached!"
+  return #hs.sys.status()
 }
 ```

--- a/docs/scripting/trust_scripts/sys.upgrade_log.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrade_log.mdx
@@ -83,6 +83,6 @@ Get a range with count:<count> and start:<offset>
 ```
 function(context, args)
 {
-	return #ms.sys.upgrade_log()
+	return #ls.sys.upgrade_log()
 }
 ```

--- a/docs/scripting/trust_scripts/sys.xfer_upgrade_to_caller.mdx
+++ b/docs/scripting/trust_scripts/sys.xfer_upgrade_to_caller.mdx
@@ -60,6 +60,6 @@ Success
 ```
 function(context, args)
 {
-	return #ls.sys.xfer_upgrade_to_caller({ i: 44 })
+	return #fs.sys.xfer_upgrade_to_caller({ i: 44 })
 }
 ```

--- a/docs/scripting/trust_scripts/trust.me.mdx
+++ b/docs/scripting/trust_scripts/trust.me.mdx
@@ -24,7 +24,7 @@ trust.me
 
 No known parameters.
 
-An example use of the function, in code, or script, in client and code
+## Example
 
 ```
 function(context, args)

--- a/docs/scripting/trust_scripts/users.inspect.mdx
+++ b/docs/scripting/trust_scripts/users.inspect.mdx
@@ -163,6 +163,6 @@ T▂T▂_
 ```
 function(context, args)
 {
-	return #ns.users.inspect({ name: "seanmakesgames" })
+	return #hs.users.inspect({ name: "seanmakesgames" })
 }
 ```

--- a/docs/scripting/trust_scripts/users.last_action.mdx
+++ b/docs/scripting/trust_scripts/users.last_action.mdx
@@ -56,6 +56,6 @@ Returns an object.
 ```
 function(context, args)
 {
-	return #ns.users.last_action({ name: "trust" })
+	return #fs.users.last_action({ name: "trust" })
 }
 ```


### PR DESCRIPTION
Several of the trust scripts' example code used seclevels which are lower than the minimum seclevel for that trust script. I've done a pass through on all of them and changed them to the appropriate seclevel.

Some other quick fixes that ended up in this PR:

* accts.xfer_gc_to_caller's example was more appropriate for xfer_gc_to, so I remade it
* sys.init cannot be subscripted (hard-blocks at parse time), so I've removed that
* sys.specs and sys.status has an example