### PR TITLE
removed the "array" parameter from scripts.lib().sort_asc/desc.mdx

### DIFF
--- a/docs/scripting/scripts.lib/sort_asc.mdx
+++ b/docs/scripting/scripts.lib/sort_asc.mdx
@@ -12,9 +12,7 @@ array.sort(#fs.scripts.lib().sort_asc);
 
 ### Parameters
 
-#### array
-
-An array of strings to be sorted in ascending order.
+No known parameters.
 
 ### Return
 

--- a/docs/scripting/scripts.lib/sort_desc.mdx
+++ b/docs/scripting/scripts.lib/sort_desc.mdx
@@ -12,9 +12,7 @@ array.sort(#fs.scripts.lib().sort_desc);
 
 ### Parameters
 
-#### array
-
-An array of strings to be sorted in descending order.
+No known parameters.
 
 ### Return
 


### PR DESCRIPTION
I don't think it's required