### PR TITLE
Add/clarify transfer limits on accts.xfer_gc_to*

### DIFF
--- a/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
@@ -26,7 +26,7 @@ accts.xfer_gc_to { to: "trust", amount: "1M234K567GC" }
 
 #### to (required)
 
-The 'to' argument specifies the target of the transaction. accts.xfer_gc_to (and accts.xfer_gc_to_caller) have a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding "trust"
+The 'to' argument specifies the target of the transaction. accts.xfer_gc_to (and accts.xfer_gc_to_caller) have a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user `trust`
 
 #### amount (required)
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
@@ -26,7 +26,7 @@ accts.xfer_gc_to { to: "trust", amount: "1M234K567GC" }
 
 #### to (required)
 
-The 'to' argument specifies the target of the transaction.
+The 'to' argument specifies the target of the transaction. accts.xfer_gc_to (and accts.xfer_gc_to_caller) have a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding "trust"
 
 #### amount (required)
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
@@ -30,7 +30,7 @@ The 'to' argument specifies the target of the transaction.
 
 #### amount (required)
 
-The 'amount' argument specifies the amount of GC to be sent. Max transfer limit is 32BGC.
+The 'amount' argument specifies the amount of GC to be sent. Max transfer limit in a single accts.xfer_gc_to execution is 32BGC.
 
 #### memo (optional)
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -2,7 +2,7 @@
 title: accts.xfer_gc_to_caller
 ---
 
-accts.xfer_gc_to_caller allows a script to send GC to the caller of the script.
+accts.xfer_gc_to_caller allows a script to send GC to the caller of the script. accts.xfer_gc_to_caller (and accts.xfer_gc_to) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding "trust"
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -2,7 +2,7 @@
 title: accts.xfer_gc_to_caller
 ---
 
-accts.xfer_gc_to_caller allows a script to send GC to the caller of the script. accts.xfer_gc_to_caller (and accts.xfer_gc_to) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding "trust"
+accts.xfer_gc_to_caller allows a script to send GC to the caller of the script. accts.xfer_gc_to_caller (and accts.xfer_gc_to) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user `trust`
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -26,7 +26,7 @@ accts.xfer_gc_to_caller
 
 #### amount (required)
 
-The 'amount' argument specifies the amount of GC to send.
+The 'amount' argument specifies the amount of GC to send. Max transfer limit in a single accts.xfer_gc_to_caller execution is 32BGC.
 
 #### memo (optional)
 


### PR DESCRIPTION
### Problem

accts.xfer_gc_to_caller does not mention the 32BGC xfer limit
accts.xfer_gc_to could do with clarification that the limit applies for every time you call it instead of top-level