### PR TITLE
Experimental pass at the CSS, to make it awesome

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,10 +20,10 @@ h5 {
   color: #ffffff;
 }
 
-a {
+a.wikilink {
   color: #385a6c;
 }
-a:visited {
+a.wikilink:visited {
   color: #8c0069;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -8,6 +8,7 @@
 
 body {
   font-family: "whiterabbit-webfont";
+  color: #7ab2f4;
 }
 
 h1,
@@ -16,6 +17,14 @@ h3,
 h4,
 h5 {
   font-family: "whiterabbit-webfont";
+  color: #ffffff;
+}
+
+a {
+  color: #385a6c;
+}
+a:visited {
+  color: #8c0069;
 }
 
 /**
@@ -24,6 +33,17 @@ h5 {
 /*.wikilink {}*/
 a.wikilink-new {
   color: var(--ifm-color-danger);
+}
+
+.main-wrapper {
+  background-color: #101215;
+  background-image: repeating-linear-gradient(
+    #0e0e0e,
+    #0e0e0e 2px,
+    #101215 2px,
+    #101215 4px
+  );
+  background-size: 100% 4px;
 }
 
 .color-tag[data-tag="a"] {


### PR DESCRIPTION
### Problem

While the addition of White Rabbit text is great, there's 2 major issues with the current hackmud wiki styling:

- it doesn't look cool/"hackmuddy" enough, and doesn't fall in line with the stylings of other official content
- there's readability problems with the existing styling. Because there's no distinguishing colors between headers and text bodies, combined with White Rabbit's weird text scaling, focusing on a page is annoying
  - This raises questions about whether these changes make it readable to a colorblind person, but that's for another issue

### Context

This is a quick, cludgy CSS pass to add a lot of the hackmud stylings to the page body.
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/7f9043fc-296a-46c9-91c7-5c2c61801cd3)

It looks pretty decent (at least in my opinion) on most pages
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/795f73aa-d27b-4b27-9f86-5d6fad9a34dc)

#### Things that need fixing

I tried to target anchor links to color them `q` and `v` for unvisited and visited respectively, but am having a hard time targeting these anchors. Maybe it's due to a lack of wikilinks (I did hard anchors for this DB page, so it could just use a pass?). Feel free to suggest whatever changes get this in.
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/3ada63d0-26b4-4fbb-94fe-e6b7f857596c)

I want to change the styling of the topbar, but didn't settle on anything ideal. Feel free to have a play around with it.
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/8f388580-044d-4208-89a3-a3177dad6041)

Light mode absolutely reeks. This is because of how I'm doing the styling in `custom.css`; I couldn't target any light mode-specific classes to make this better. Someone smarter may need to work this out (or disable light mode altogether?)
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/480d11a1-53fd-4fe4-8e89-2ce6abb24362)
