### PR TITLE
Fix autocolor bounds

### DIFF
--- a/docs/autocolor_demo.mdx
+++ b/docs/autocolor_demo.mdx
@@ -22,3 +22,9 @@ unlisted: true
 ### complex
 
 (( %X>>trust.me \{key: "value", key: \{}, key: #s.mallory.starchart, amount: "2B1KGC"}% ))
+
+### In a paragraph
+
+Raw markup, followed by resulting HTML:  
+`hackmud.com should not be colored, but (( %3THIS SHOULD BE BLUE% ))`  
+hackmud.com should not be colored, but (( %3THIS SHOULD BE BLUE% ))

--- a/src/plugins/rehype/autocolor.js
+++ b/src/plugins/rehype/autocolor.js
@@ -96,7 +96,22 @@ function colorGC(_fullMatch, q, t, b, m, k, units) {
 }
 
 function colorBlock(_fullMatch, content) {
-  return content;
+  const stubNode = {
+    type: "root",
+    children: [
+      {
+        type: "text",
+        value: content,
+      },
+    ],
+  };
+  findAndReplace(stubNode, [
+    [regexColorTag, colorTag],
+    [regexKvp, colorKvp],
+    [regexScript, colorScript],
+    [regexGC, colorGC],
+  ]);
+  return stubNode.children;
 }
 
 const autocolorPlugin = (_config) => {
@@ -109,13 +124,7 @@ const autocolorPlugin = (_config) => {
           type: "root",
           children: [node],
         };
-        findAndReplace(stubNode, [
-          [regexAutocolorBlock, colorBlock],
-          [regexColorTag, colorTag],
-          [regexKvp, colorKvp],
-          [regexScript, colorScript],
-          [regexGC, colorGC],
-        ]);
+        findAndReplace(stubNode, [regexAutocolorBlock, colorBlock]);
         parent.children.splice(
           parent.children.indexOf(node),
           1,


### PR DESCRIPTION
### Problem
Fixes #363.

Existing behavior:
![image](https://github.com/comcode-org/hackmud_wiki/assets/1775803/19835dde-4c98-4d1d-826b-ff370b316927)

Desired behavior:
![image](https://github.com/comcode-org/hackmud_wiki/assets/1775803/70e5766d-5617-4742-8018-e025ad61536b)


### Context
Moved script / keyval / color-code / GC regex replacements to only act on the content match from the boundary ( `(( ))` ) regex. Requires a stub node in both cases. We are operating on text nodes one at a time, but text nodes cannot have children, so we have to make a fake parent whose only child is the bit we're interested in.

Can be manually verified by starting the dev server and manually navigating to the unlisted page at `/autocolor_demo`.
