### PR TITLE
Update db.objectid.mdx to use colored spans for highlighting

### DIFF
--- a/docs/scripting/db/db.objectid.mdx
+++ b/docs/scripting/db/db.objectid.mdx
@@ -20,8 +20,7 @@ ObjectIds convey a variety of information, consisting of:
 - A 5-byte value denoting the <span class="color-tag" data-tag="L">worker ID</span> the ObjectId was generated on (static across hackmud's workers), as well as the <span class="color-tag" data-tag="J">thread ID</span> it was generated on
 - A <span class="color-tag" data-tag="V">3-byte incrementing counter</span>
 
-<!-- prettier-ignore -->
-<p><span class="color-tag" data-tag="D">65eaa465</span><span class="color-tag" data-tag="L">7b97fd</span><span class="color-tag" data-tag="J">26dd</span><span class="color-tag" data-tag="V">0c5305</span>
+"<span class="color-tag" data-tag="D">65eaa465</span><span class="color-tag" data-tag="L">7b97fd</span><span class="color-tag" data-tag="J">26dd</span><span class="color-tag" data-tag="V">0c5305</span>"
 
 ## Example
 

--- a/docs/scripting/db/db.objectid.mdx
+++ b/docs/scripting/db/db.objectid.mdx
@@ -20,18 +20,8 @@ ObjectIds convey a variety of information, consisting of:
 - A 5-byte value denoting the <span class="color-tag" data-tag="L">worker ID</span> the ObjectId was generated on (static across hackmud's workers), as well as the <span class="color-tag" data-tag="J">thread ID</span> it was generated on
 - A <span class="color-tag" data-tag="V">3-byte incrementing counter</span>
 
-<span class="color-tag" data-tag="D">
-  65eaa465
-</span>
-<span class="color-tag" data-tag="L">
-  7b97fd
-</span>
-<span class="color-tag" data-tag="J">
-  26dd
-</span>
-<span class="color-tag" data-tag="V">
-  0c5305
-</span>
+<!-- prettier-ignore -->
+<p><span class="color-tag" data-tag="D">65eaa465</span><span class="color-tag" data-tag="L">7b97fd</span><span class="color-tag" data-tag="J">26dd</span><span class="color-tag" data-tag="V">0c5305</span>
 
 ## Example
 

--- a/docs/scripting/db/db.objectid.mdx
+++ b/docs/scripting/db/db.objectid.mdx
@@ -20,10 +20,18 @@ ObjectIds convey a variety of information, consisting of:
 - A 5-byte value denoting the <span class="color-tag" data-tag="L">worker ID</span> the ObjectId was generated on (static across hackmud's workers), as well as the <span class="color-tag" data-tag="J">thread ID</span> it was generated on
 - A <span class="color-tag" data-tag="V">3-byte incrementing counter</span>
 
-<span class="color-tag" data-tag="D">65eaa465</span>
-<span class="color-tag" data-tag="L">7b97fd</span>
-<span class="color-tag" data-tag="J">26dd</span>
-<span class="color-tag" data-tag="V">0c5305</span>
+<span class="color-tag" data-tag="D">
+  65eaa465
+</span>
+<span class="color-tag" data-tag="L">
+  7b97fd
+</span>
+<span class="color-tag" data-tag="J">
+  26dd
+</span>
+<span class="color-tag" data-tag="V">
+  0c5305
+</span>
 
 ## Example
 

--- a/docs/scripting/db/db.objectid.mdx
+++ b/docs/scripting/db/db.objectid.mdx
@@ -4,16 +4,6 @@ title: "#db.ObjectId()"
 
 Generates a MongoDB ObjectId.
 
-export const Highlight = ({ children, color }) => (
-  <span
-    style={{
-      color: color,
-    }}
-  >
-    {children}
-  </span>
-);
-
 [MongoDB ObjectIds](https://www.mongodb.com/docs/manual/reference/method/ObjectId/) are a 12-byte, unique value primarily used for marking unique documents in the db. #db.ObjectId() can be used to generate arbitrary, unique ObjectIds.
 
 ## Syntax
@@ -26,14 +16,14 @@ export const Highlight = ({ children, color }) => (
 
 ObjectIds convey a variety of information, consisting of:
 
-- A <Highlight color="red">4-byte timestamp</Highlight>, measured in seconds since the Unix epoch. This timestamp marks the time the ObjectId was generated
-- A 5-byte value denoting the <Highlight color="green">worker ID</Highlight> the ObjectId was generated on (static across hackmud's workers), as well as the <Highlight color="orange">thread ID</Highlight> it was generated on
-- A <Highlight color="purple">3-byte incrementing counter</Highlight>
+- A <span class="color-tag" data-tag="D">4-byte timestamp</span>, measured in seconds since the Unix epoch. This timestamp marks the time the ObjectId was generated
+- A 5-byte value denoting the <span class="color-tag" data-tag="L">worker ID</span> the ObjectId was generated on (static across hackmud's workers), as well as the <span class="color-tag" data-tag="J">thread ID</span> it was generated on
+- A <span class="color-tag" data-tag="V">3-byte incrementing counter</span>
 
-<Highlight color="red">65eaa465</Highlight>
-<Highlight color="green">7b97fd</Highlight>
-<Highlight color="yellow">26dd</Highlight>
-<Highlight color="purple">0c5305</Highlight>
+<span class="color-tag" data-tag="D">65eaa465</span>
+<span class="color-tag" data-tag="L">7b97fd</span>
+<span class="color-tag" data-tag="J">26dd</span>
+<span class="color-tag" data-tag="V">0c5305</span>
 
 ## Example
 


### PR DESCRIPTION
### Problem

The page for #db.ObjectId() uses a Docusaurus highlighting function (including a chunk of code in the page itself) for coloring. I did this at like 3 AM prior to the site redesign; it is obsoleted by existing CSS styling, and should in any case be updated to use in-game hackmud colors

### Context

Switched the weird Highlight function and made-up HTML tag for spans that use the `color-tag` class. The colors also pop a bit better than the default HTML color names, and contrast with the background better

![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/7354ac79-186a-48ef-9f04-ca77858fc976)

![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/3697f262-b085-4771-bf1c-c4cc77b86bdc)
![image](https://github.com/comcode-org/hackmud_wiki/assets/53655672/52ac172e-54e6-4b49-89cc-f11e0ad70790)
