### PR TITLE
Normalise the example loc script to 'user.loc'

### DIFF
--- a/docs/scripting/db/db.objectid.mdx
+++ b/docs/scripting/db/db.objectid.mdx
@@ -4,16 +4,6 @@ title: "#db.ObjectId()"
 
 Generates a MongoDB ObjectId.
 
-export const Highlight = ({ children, color }) => (
-  <span
-    style={{
-      color: color,
-    }}
-  >
-    {children}
-  </span>
-);
-
 [MongoDB ObjectIds](https://www.mongodb.com/docs/manual/reference/method/ObjectId/) are a 12-byte, unique value primarily used for marking unique documents in the db. #db.ObjectId() can be used to generate arbitrary, unique ObjectIds.
 
 ## Syntax
@@ -26,14 +16,11 @@ export const Highlight = ({ children, color }) => (
 
 ObjectIds convey a variety of information, consisting of:
 
-- A <Highlight color="red">4-byte timestamp</Highlight>, measured in seconds since the Unix epoch. This timestamp marks the time the ObjectId was generated
-- A 5-byte value denoting the <Highlight color="green">worker ID</Highlight> the ObjectId was generated on (static across hackmud's workers), as well as the <Highlight color="orange">thread ID</Highlight> it was generated on
-- A <Highlight color="purple">3-byte incrementing counter</Highlight>
+- A <span class="color-tag" data-tag="D">4-byte timestamp</span>, measured in seconds since the Unix epoch. This timestamp marks the time the ObjectId was generated
+- A 5-byte value denoting the <span class="color-tag" data-tag="L">worker ID</span> the ObjectId was generated on (static across hackmud's workers), as well as the <span class="color-tag" data-tag="J">thread ID</span> it was generated on
+- A <span class="color-tag" data-tag="V">3-byte incrementing counter</span>
 
-<Highlight color="red">65eaa465</Highlight>
-<Highlight color="green">7b97fd</Highlight>
-<Highlight color="yellow">26dd</Highlight>
-<Highlight color="purple">0c5305</Highlight>
+"<span class="color-tag" data-tag="D">65eaa465</span><span class="color-tag" data-tag="L">7b97fd</span><span class="color-tag" data-tag="J">26dd</span><span class="color-tag" data-tag="V">0c5305</span>"
 
 ## Example
 

--- a/docs/scripting/trust_scripts/sys.loc.mdx
+++ b/docs/scripting/trust_scripts/sys.loc.mdx
@@ -34,7 +34,7 @@ Returns a string.
 
 ```
 >>sys.loc
-user.fakeloc123
+user.loc
 ```
 
 #### Script

--- a/docs/upgrades/infiltrator/expose_access_log_v1.mdx
+++ b/docs/upgrades/infiltrator/expose_access_log_v1.mdx
@@ -21,7 +21,7 @@ The 'count' stat displays the number of access logs can be exposed by the expose
 When a player has this upgrade loaded, the upgrade can be executed against a breached system using the following syntax:
 
 ```
->>sys.expose_access_log { target: "user.fakeloc123" }
+>>sys.expose_access_log { target: "user.loc" }
 ```
 
 If a player attempts to execute this upgrade in an invalid use case, the upgrade will return corresponding errors.
@@ -32,7 +32,7 @@ Examples:
 
 ```
 
->>sys.expose_access_log { target: "user.fakeloc123" }
+>>sys.expose_access_log { target: "user.loc" }
 :::TRUST COMMUNICATION::: hardline required - activate with kernel.hardline
 
 ```
@@ -41,16 +41,16 @@ Examples:
 
 ```
 
->> sys.expose_access_log { target: "user.fakeloc123" }
+>> sys.expose_access_log { target: "user.loc" }
 Failure
-Target user.fakeloc123 is not a breached system.
+Target user.loc is not a breached system.
 
 ```
 
 - Upgrade on cooldown:
 
 ```
->>sys.expose_access_log { target: "user.fakeloc123" }
+>>sys.expose_access_log { target: "user.loc" }
 Failure
 sys.expose_access_log is still recalibrating. 12 minutes until ready.
 ```
@@ -58,7 +58,7 @@ sys.expose_access_log is still recalibrating. 12 minutes until ready.
 - Not enough GC on system:
 
 ```
->>sys.expose_access_log { target: "user.fakeloc123" }
+>>sys.expose_access_log { target: "user.loc" }
 Failure
 Your account balance of 0GC is too low to send 50KGC.
 ```

--- a/docs/upgrades/infiltrator/log_writer_v1.mdx
+++ b/docs/upgrades/infiltrator/log_writer_v1.mdx
@@ -17,7 +17,7 @@ The 'cooldown' stat, which is displayed in seconds, determines how much time mus
 Once a log_writer_v1 upgrade has been loaded, [[sys.write_log]] can be run against a breached system for a cost of 500KGC, which allows the breacher to leave a message in the target's [[access_log]]. The amount of [[GC]] required is displayed upon execution attempt. If the specific log_writer_v1 upgrade is on cooldown, an error containing the remaining cooldown time will be displayed upon execution attempt. For syntax information see [[sys.write_log]].
 
 ```
->>sys.write_log { target: "user.fakeloc123", msg: "you got hacked" }
+>>sys.write_log { target: "user.loc", msg: "you got hacked" }
 Success
 
 Transferred 500KGC to trust

--- a/docs/upgrades/locks/DATA_CHECK_V1.mdx
+++ b/docs/upgrades/locks/DATA_CHECK_V1.mdx
@@ -52,6 +52,8 @@ pet, pest, plague and meme are accurate descriptors of the ++++++
 >>user.loc { DATA_CHECK:"robovacget_levelbunnybat" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
+System <user> breached.
+Connection terminated.
 ```
 
 </details>

--- a/docs/upgrades/locks/DATA_CHECK_V1.mdx
+++ b/docs/upgrades/locks/DATA_CHECK_V1.mdx
@@ -18,7 +18,7 @@ DATA_CHECK_V1 expects the answers to three questions concatenated together into 
 When no arguments are passed into DATA_CHECK_V1, the lock will return the following error:
 
 ```
-user.fakeloc123 { }
+user.loc { }
 LOCK_ERROR
 Denied access by DATA_CHECK lock.
 ```
@@ -28,7 +28,7 @@ Note that the '\_v1' at the end of DATA_CHECK is not included in the argument ke
 Providing any incorrect value to the DATA_CHECK key will provide 3 questions to answer:
 
 ```
->>user.fakeloc123 { DATA_CHECK:"" }
+>>user.loc { DATA_CHECK:"" }
 a ++++++ is a household cleaning device with a rudimentary networked sentience
 safety depends on the use of scripts.++++++
 pet, pest, plague and meme are accurate descriptors of the ++++++
@@ -44,12 +44,12 @@ All 3 questions must be answered in the order received, concatenated together in
   <summary>Spoilers for DATA_CHECK_V1's solutions</summary>
 
 ```
->>user.fakeloc123 { DATA_CHECK:"" }
+>>user.loc { DATA_CHECK:"" }
 a ++++++ is a household cleaning device with a rudimentary networked sentience
 safety depends on the use of scripts.++++++
 pet, pest, plague and meme are accurate descriptors of the ++++++
 
->>user.fakeloc123 { DATA_CHECK:"robovacget_levelbunnybat" }
+>>user.loc { DATA_CHECK:"robovacget_levelbunnybat" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 ```

--- a/docs/upgrades/locks/c001.mdx
+++ b/docs/upgrades/locks/c001.mdx
@@ -15,7 +15,7 @@ c001 has no additional stats. The upgrade only spawns at 'kiddie' rarity.
 When loaded on a targetted [[loc]], the following text will be displayed when no arguments are provided:
 
 ```
->>user.fakeloc123 { }
+>>user.loc { }
 LOCK_ERROR
 Denied access by CORE c001 lock.
 ```
@@ -23,7 +23,7 @@ Denied access by CORE c001 lock.
 When providing any truthy argument (or an empty string `""`), the lock will state that the correct color was not provided, unless the correct color is provided:
 
 ```
->>user.fakeloc123 { c001:"not_a_color"}
+>>user.loc { c001:"not_a_color"}
 LOCK_ERROR
 "not_a_color" is not the correct color name.
 ```

--- a/docs/upgrades/locks/c002.mdx
+++ b/docs/upgrades/locks/c002.mdx
@@ -15,6 +15,7 @@ c002 has no additional stats. The upgrade only spawns at kiddie rarity.
 When loaded on a targetted [[loc]], the following text will be displayed when no arguments are provided:
 
 ```
+>>user.loc { }
 LOCK_ERROR
 Denied access by CORE c002 lock.
 ```
@@ -22,8 +23,9 @@ Denied access by CORE c002 lock.
 When providing any truthy argument (or an empty string `""`), the lock will state that the correct color was not provided, unless the correct color is provided:
 
 ```
+>>user.loc {c002:"not_a_color"}
 LOCK_ERROR
-<input> is not the correct color name.
+"not_a_color" is not the correct color name.
 ```
 
 Its second stage will state that the additional argument `c002_complement` is missing, or that its input isn't the correct color name.

--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -15,7 +15,7 @@ c003 has no additional stats. The upgrade only spawns at 'kiddie' rarity.
 When loaded on a targetted [[loc]], the following text will be displayed when no arguments are provided:
 
 ```
->>user.fakeloc123 {}
+>>user.loc {}
 LOCK_ERROR
 Denied access by CORE c003 lock.
 ```
@@ -23,7 +23,7 @@ Denied access by CORE c003 lock.
 When providing any truthy argument (or an empty string `""`), the lock will state that the correct color was not provided, unless the correct color is provided:
 
 ```
->>user.fakeloc123 { c003: "not_a_color" }
+>>user.loc { c003: "not_a_color" }
 LOCK_ERROR
 "not_a_color" is not the correct color name.
 ```
@@ -38,7 +38,7 @@ c003 requires three arguments to fully solve: (( %Nc003%, %Nc003_triad_1%, and %
 <summary>Spoilers</summary>
 
 ```
->>user.fakeloc123 { c003: "red", c003_triad_1: "cyan", c003_triad_2: "lime" }
+>>user.loc { c003: "red", c003_triad_1: "cyan", c003_triad_2: "lime" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 System user breached.

--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -41,7 +41,7 @@ c003 requires three arguments to fully solve: (( %Nc003%, %Nc003_triad_1%, and %
 >>user.loc { c003: "red", c003_triad_1: "cyan", c003_triad_2: "lime" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
-System user breached.
+System <user> breached.
 Connection terminated.
 ```
 

--- a/docs/upgrades/locks/ez_21.mdx
+++ b/docs/upgrades/locks/ez_21.mdx
@@ -21,7 +21,7 @@ When encountered, the lock expects a string as its parameter, and will return an
 <details>
   <summary>Spoilers</summary>
 ```
->>user.fakeloc123 { ez_21: "open" }
+>>user.loc { ez_21: "open" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 System user breached.

--- a/docs/upgrades/locks/ez_21.mdx
+++ b/docs/upgrades/locks/ez_21.mdx
@@ -24,7 +24,7 @@ When encountered, the lock expects a string as its parameter, and will return an
 >>user.loc { ez_21: "open" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
-System user breached.
+System <user> breached.
 Connection terminated.
 ```
 </details>

--- a/docs/upgrades/locks/ez_35.mdx
+++ b/docs/upgrades/locks/ez_35.mdx
@@ -17,11 +17,11 @@ When encountered, the lock expects a string as its first parameter, and a digit 
 ```
 Incorrect parameters:
 
->>user.fakeloc123 { ez_35: 1 }
+>>user.loc { ez_35: 1 }
 LOCK_ERROR
 1 is not a string.
 
->>user.fakeloc123 { ez_35: "release", digit: "1" }
+>>user.loc { ez_35: "release", digit: "1" }
 LOCK_ERROR
 "1" is not a number.
 ```
@@ -33,7 +33,7 @@ LOCK_ERROR
 <details>
 <summary>Spoilers for ez_35's solutions</summary>
 ```
->>user.fakeloc123 { ez_35: "open", digit: 0 }
+>>user.loc { ez_35: "open", digit: 0 }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 System <user> breached.
@@ -48,7 +48,7 @@ Connection terminated.
   The first parameter's possible strings are, "open", "unlock", and "release".
   
 ```
->>user.fakeloc123 { }
+>>user.loc { }
 LOCK_ERROR
 Denied access by HALPERYON SYSTEMS EZ_35 lock.
 ```
@@ -56,7 +56,7 @@ Denied access by HALPERYON SYSTEMS EZ_35 lock.
 When given the correct string, the lock will return an error giving instructions for the second parameter.
 
 ```
->>user.fakeloc123 { ez_35: "release" }
+>>user.loc { ez_35: "release" }
 LOCK_ERROR
 Required unlock parameter digit is missing.
 
@@ -71,7 +71,7 @@ Required unlock parameter digit is missing.
   The second parameter is a single digit, input as a number, ranging from 0 to 9.
 
 ```
-user.fakeloc123 { ez_35: "release", digit: 1 }
+user.loc { ez_35: "release", digit: 1 }
 ```
 
 </details>

--- a/docs/upgrades/locks/ez_35.mdx
+++ b/docs/upgrades/locks/ez_35.mdx
@@ -14,12 +14,12 @@ ez_35 has no additional stats. The upgrade only spawns at 'noob' rarity.
 
 When encountered, the lock expects a string as its first parameter, and a digit as its second. Each parameter will return corresponding errors if an incorrect data type is input.
 
-```
-Incorrect parameters:
+### Incorrect Parameters
 
->>user.loc { ez_35: 1 }
+```
+>>user.loc { ez_35: true }
 LOCK_ERROR
-1 is not a string.
+true is not a string.
 
 >>user.loc { ez_35: "release", digit: "1" }
 LOCK_ERROR

--- a/docs/upgrades/locks/ez_40.mdx
+++ b/docs/upgrades/locks/ez_40.mdx
@@ -14,12 +14,12 @@ This upgrade has no additional stats and only spawns at 'kiddie' rarity.
 
 When encountered, the ez_40 will ask for a string on its first parameter, and a digit (number) on its second parameter.
 
-```
-Incorrect parameters:
+### Incorrect Parameters
 
->>user.loc { ez_40: 1 }
+```
+>>user.loc { ez_40: true }
 LOCK_ERROR
-1 is not a string.
+true is not a string.
 
 >>user.loc { ez_40: "release", ez_prime: "1" }
 LOCK_ERROR

--- a/docs/upgrades/locks/ez_40.mdx
+++ b/docs/upgrades/locks/ez_40.mdx
@@ -17,21 +17,21 @@ When encountered, the ez_40 will ask for a string on its first parameter, and a 
 ```
 Incorrect parameters:
 
->>user.fakeloc123 { ez_40: 1 }
+>>user.loc { ez_40: 1 }
 LOCK_ERROR
 1 is not a string.
 
->>user.fakeloc123 { ez_40: "release", ez_prime: "1" }
+>>user.loc { ez_40: "release", ez_prime: "1" }
 LOCK_ERROR
 "1" is not a number.
 
 Correct parameters:
 
->>user.fakeloc123 { ez_40: "release" }
+>>user.loc { ez_40: "release" }
 LOCK_ERROR
 Required unlock parameter ez_prime is missing.
 
->>user.fakeloc123 { ez_40: "release", ez_prime: 2 }
+>>user.loc { ez_40: "release", ez_prime: 2 }
 LOCK_ERROR
 2 is not the correct prime.
 ```
@@ -44,7 +44,7 @@ LOCK_ERROR
   <summary>Spoilers for ez_40 example unlock</summary>
 
 ```
->>user.fakeloc123 { ez_40: "release", ez_prime: 43 }
+>>user.loc { ez_40: "release", ez_prime: 43 }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 System <user> breached.

--- a/docs/upgrades/locks/l0cket.mdx
+++ b/docs/upgrades/locks/l0cket.mdx
@@ -16,7 +16,7 @@ l0cket expects one of several possible [[k3y_v1]] values to be passed as a strin
 When an incorrect string is passed, l0cket will present the following error information:
 
 ```
-user.fakeloc123 { l0cket:"not_a_k3y" }
+user.loc { l0cket:"not_a_k3y" }
 LOCK_ERROR
 "not_a_k3y" is not the correct security k3y.
 ```
@@ -29,7 +29,7 @@ LOCK_ERROR
   <summary>Spoilers for l0cket's solutions</summary>
 
 ```
->>user.fakeloc123 { l0cket: "6hh8xw" }
+>>user.loc { l0cket: "6hh8xw" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
 System beta breached.

--- a/docs/upgrades/locks/l0cket.mdx
+++ b/docs/upgrades/locks/l0cket.mdx
@@ -32,7 +32,7 @@ LOCK_ERROR
 >>user.loc { l0cket: "6hh8xw" }
 WARNING: BINMAT security shell inactive. Intelligent defense system offline.
 LOCK_UNLOCKED
-System beta breached.
+System <user> breached.
 Connection terminated.
 
 ```

--- a/docs/upgrades/scavenger/transfer_v1.mdx
+++ b/docs/upgrades/scavenger/transfer_v1.mdx
@@ -24,7 +24,7 @@ If the upgrade is on cooldown, an error containing the remaining cooldown time w
 [[sys.xfer_gc_from]] can be executed using the following syntax:
 
 ```
-sys.xfer_gc_from { target: "user.fakeloc123", amount: "<desired amount (up to max) as GC string>" }
+sys.xfer_gc_from { target: "user.loc", amount: "<desired amount (up to max) as GC string>" }
 ```
 
 If a player attempts to execute this upgrade in an invalid use case, the upgrade will return corresponding errors.
@@ -35,7 +35,7 @@ Examples:
 
 ```
 
->>sys.xfer_gc_from { target: "user.fakeloc123", amount: "10KGC" }
+>>sys.xfer_gc_from { target: "user.loc", amount: "10KGC" }
 :::TRUST COMMUNICATION::: hardline required - activate with kernel.hardline
 
 ```
@@ -44,16 +44,16 @@ Examples:
 
 ```
 
->>sys.xfer_gc_from { target: "user.fakeloc123", amount: "10M500KGC" }
+>>sys.xfer_gc_from { target: "user.loc", amount: "10M500KGC" }
 Failure
-Target user.fakeloc123 is not a breached system.
+Target user.loc is not a breached system.
 
 ```
 
 - Upgrade on cooldown:
 
 ```
->>sys.xfer_gc_from { target: "user.fakeloc123", amount: "100B100MGC" }
+>>sys.xfer_gc_from { target: "user.loc", amount: "100B100MGC" }
 Failure
 sys.xfer_gc_from is still recalibrating. 12 minutes until ready.
 ```
@@ -61,7 +61,7 @@ sys.xfer_gc_from is still recalibrating. 12 minutes until ready.
 - Amount is higher than the maximum allowed by upgrade:
 
 ```
->>sys.xfer_gc_from { target: "user.fakeloc123", amount: "10TGC" }
+>>sys.xfer_gc_from { target: "user.loc", amount: "10TGC" }
 Failure
 You can't transfer more than 10MGC
 ```
@@ -69,7 +69,7 @@ You can't transfer more than 10MGC
 - Target has unsufficient funds:
 
 ```
->>sys.xfer_gc_from { target: "user.fakeloc123", amount: "10KGC" }
+>>sys.xfer_gc_from { target: "user.loc", amount: "10KGC" }
 Failure
 Target user account balance is too low to take 10KGC.
 ```


### PR DESCRIPTION
### Problem

On lock pages, and other pages that need an example loc command, there is inconsistency between what loc script is used as a placeholder. Some pages use `user.loc` while others use `user.fakeloc123`

### Context

This PR normalises all of the example locs on the lock articles to `user.loc`. It also checks in a handful of small cleanups to the articles that I noticed while checking them.