### PR TITLE
Move dependency upgrade instructions to the bottom of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,38 +20,6 @@
 1. Navigate to the URL specified in the console or allow the browser to open it automatically
    - e.g. `[SUCCESS] Docusaurus website is running at: <website_url>`
 
-## Dependency Upgrades
-
-Our projects depend on many pre-existing and separately maintained packages. These packages are regularly updated for security issues, features, and other issues.
-
-### Policy & Values
-
-1. We regularly update our packages to make sure that our individual changes are small. This makes debugging and review easier.
-1. We optimistically take compatible versions as they are available.
-1. We update major version changes in packages when they are 'out of beta' and had 'enough bake time'.
-1. We create issues for major version upgrades. Issues are not needed for other upgrades.
-1. We document any upgrade specific decisions in the created issue for that upgrade.
-1. We rely on tools and test automation wherever possible to reduce the cost on the team for package updates.
-1. We use team judgment, validate our assumptions with others and make exceptions to our policy where appropriate.
-
-### Upgrade Process
-
-This upgrade process is written for a major version upgrade with breaking changes which directly have impact on our project. This process is based on [the webpack major version upgrade guide](https://webpack.js.org/migrate/5/). The process can be remixed and composed to handle any size and sets of dependency upgrades. For simpler upgrades, only do the steps which are applicable. All PRs should be the smallest possible and maintain the release-ability of the production branch.
-
-1. Identify any specific guides for the major version upgrade. Follow them if available
-1. If we are upgrading multiple major versions, we do them in sequence one at a time
-1. Identify any required dependent loaders, plugins or package version requirements, run the upgrade process for them
-1. Create `topic branch`
-1. Upgrade package to latest version with the same major version. (compatible semver)
-1. Fix all build warnings and deprecations
-1. Migrate any compatible build flags
-1. Run tests and turn on any 'major version mode' compatability testing flags during testing (revert before merge)
-1. Create PR on `topic branch` and merge with standard process
-1. Create new `topic branch`
-1. Upgrade package to next major version
-1. Clean up and migrate any incompatible build flags
-1. Create PR on new `topic branch` and merge with standard process
-
 ## Content Guide
 
 ### General
@@ -188,3 +156,35 @@ Dolor icecream :)
 
 1. Use existing templates.
 1. If a template does not exist for what you want to make, propose a new one via a pull request.
+
+## Dependency Upgrades
+
+Our projects depend on many pre-existing and separately maintained packages. These packages are regularly updated for security issues, features, and other issues.
+
+### Policy & Values
+
+1. We regularly update our packages to make sure that our individual changes are small. This makes debugging and review easier.
+1. We optimistically take compatible versions as they are available.
+1. We update major version changes in packages when they are 'out of beta' and had 'enough bake time'.
+1. We create issues for major version upgrades. Issues are not needed for other upgrades.
+1. We document any upgrade specific decisions in the created issue for that upgrade.
+1. We rely on tools and test automation wherever possible to reduce the cost on the team for package updates.
+1. We use team judgment, validate our assumptions with others and make exceptions to our policy where appropriate.
+
+### Upgrade Process
+
+This upgrade process is written for a major version upgrade with breaking changes which directly have impact on our project. This process is based on [the webpack major version upgrade guide](https://webpack.js.org/migrate/5/). The process can be remixed and composed to handle any size and sets of dependency upgrades. For simpler upgrades, only do the steps which are applicable. All PRs should be the smallest possible and maintain the release-ability of the production branch.
+
+1. Identify any specific guides for the major version upgrade. Follow them if available
+1. If we are upgrading multiple major versions, we do them in sequence one at a time
+1. Identify any required dependent loaders, plugins or package version requirements, run the upgrade process for them
+1. Create `topic branch`
+1. Upgrade package to latest version with the same major version. (compatible semver)
+1. Fix all build warnings and deprecations
+1. Migrate any compatible build flags
+1. Run tests and turn on any 'major version mode' compatability testing flags during testing (revert before merge)
+1. Create PR on `topic branch` and merge with standard process
+1. Create new `topic branch`
+1. Upgrade package to next major version
+1. Clean up and migrate any incompatible build flags
+1. Create PR on new `topic branch` and merge with standard process


### PR DESCRIPTION
### Problem

A new reader of the README will likely want to know the content guide over how to update dependent packages (especially now that dependabot is handling non-conflicting patches)

### Context

This PR moves the content guide to the 2nd header of the README, to make it more accessible at a glance. Feel free to close this PR if this is not desired