### PR TITLE
Remove player scriptname from escrow.confirm

### DIFF
--- a/docs/scripting/trust_scripts/escrow.confirm.mdx
+++ b/docs/scripting/trust_scripts/escrow.confirm.mdx
@@ -47,7 +47,7 @@ Valid token, no confirmation:
 ```
 >>escrow.confirm { i: "token5" }
 Failure
-Confirm escrow account of 1GC for each use of kbeeb.specs with confirm:true
+Confirm escrow account of 1GC for each use of user.script with confirm:true
 ```
 
 Valid token and confirmation:
@@ -55,7 +55,7 @@ Valid token and confirmation:
 ```
 >>escrow.confirm { i: "token5", confirm: true }
 Success
-Escrow confirmed. You may now use <users.script>. You will need to reconfirm in 30 days or if the cost changes
+Escrow confirmed. You may now use user.script. You will need to reconfirm in 30 days or if the cost changes
 ```
 
 #### Script


### PR DESCRIPTION
### Problem

`kbeeb.specs` is inside of `escrow.confirm`'s example outputs.

### Context

This PR changes it to `user.script`