### PR TITLE
Add in-game colors to rarity names

### DIFF
--- a/docs/upgrades/architect/char_count_v1.mdx
+++ b/docs/upgrades/architect/char_count_v1.mdx
@@ -5,7 +5,7 @@ alias: char_count
 
 > char_count adds space for additional characters in every script.
 
-char_count_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+char_count_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/architect/cron_bot_v1.mdx
+++ b/docs/upgrades/architect/cron_bot_v1.mdx
@@ -5,7 +5,7 @@ alias: cron_bot
 
 > bot_brain upgrades will call your bot_brain script based on the upgrade's cooldown interval, allowing you to automate your user.
 
-cron_bot_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+cron_bot_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/architect/public_script_v1.mdx
+++ b/docs/upgrades/architect/public_script_v1.mdx
@@ -4,7 +4,7 @@ title: public_script_v1
 
 > public_script_slot allows you to mark scripts as public.
 
-public_script_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+public_script_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/architect/script_slot_v1.mdx
+++ b/docs/upgrades/architect/script_slot_v1.mdx
@@ -4,7 +4,7 @@ title: script_slot_v1
 
 > script_slot allows you to increase your script slots.
 
-script_slot_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+script_slot_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/executive/channel_count_v1.mdx
+++ b/docs/upgrades/executive/channel_count_v1.mdx
@@ -4,7 +4,7 @@ title: channel_count_v1
 
 > channel_count allows you to connect to more chat channels.
 
-channel_count_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+channel_count_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/infiltrator/expose_access_log_v1.mdx
+++ b/docs/upgrades/infiltrator/expose_access_log_v1.mdx
@@ -4,7 +4,7 @@ title: expose_access_log_v1
 
 > sys.expose_access_log allows you to view the access log of a compromised system.
 
-expose_access_log_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie', and 'h4x0r' rarities.
+expose_access_log_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))', and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/infiltrator/k3y_v1.mdx
+++ b/docs/upgrades/infiltrator/k3y_v1.mdx
@@ -4,7 +4,7 @@ title: k3y_v1
 
 > Keep your nuutec l0cket safe with a security k3y
 
-k3y_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie' and 'h4x0r' rarities.
+k3y_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))' and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/infiltrator/log_writer_v1.mdx
+++ b/docs/upgrades/infiltrator/log_writer_v1.mdx
@@ -4,7 +4,7 @@ title: log_writer_v1
 
 > sys.write_log allows you to write a log to a compromised system.
 
-log_writer_v1 is a tier 1 upgrade. It spawns at 'noob', 'kiddie' and 'h4x0r' rarities.
+log_writer_v1 is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))' and '((%2h4x0r%))' rarities.
 
 ## Stats
 

--- a/docs/upgrades/locks/CON_TELL.mdx
+++ b/docs/upgrades/locks/CON_TELL.mdx
@@ -8,7 +8,7 @@ CON_TELL is a tier 1 [[lock]].
 
 ## Stats
 
-CON_TELL has no additional stats. The upgrade only spawns at 'kiddie' rarity.
+CON_TELL has no additional stats. The upgrade only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/c001.mdx
+++ b/docs/upgrades/locks/c001.mdx
@@ -8,7 +8,7 @@ c001 is a tier 1 [[lock]] created by the CORE corporation.
 
 ## Stats
 
-c001 has no additional stats. The upgrade only spawns at 'kiddie' rarity.
+c001 has no additional stats. The upgrade only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/c002.mdx
+++ b/docs/upgrades/locks/c002.mdx
@@ -8,7 +8,7 @@ c002 is a tier 1 [[lock]] created by the CORE corporation.
 
 ## Stats
 
-c002 has no additional stats. The upgrade only spawns at kiddie rarity.
+c002 has no additional stats. The upgrade only spawns at ((%1kiddie%)) rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -8,7 +8,7 @@ c003 is a tier 1 lock created by the CORE corporation.
 
 ## Stats
 
-c003 has no additional stats. The upgrade only spawns at 'kiddie' rarity.
+c003 has no additional stats. The upgrade only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/ez_21.mdx
+++ b/docs/upgrades/locks/ez_21.mdx
@@ -8,7 +8,7 @@ ez_21 is a tier 1 [[lock]] created by the HALPERYON SYSTEMS corporation.
 
 ### Stats
 
-ez_21 has no additional stats. The upgrade only spawns at 'noob' rarity.
+ez_21 has no additional stats. The upgrade only spawns at '((%0noob%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/ez_35.mdx
+++ b/docs/upgrades/locks/ez_35.mdx
@@ -8,7 +8,7 @@ ez_35 is a tier 1 [[lock]] created by Halperyon Systems.
 
 ### Stats
 
-ez_35 has no additional stats. The upgrade only spawns at 'noob' rarity.
+ez_35 has no additional stats. The upgrade only spawns at '((%0noob%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/ez_40.mdx
+++ b/docs/upgrades/locks/ez_40.mdx
@@ -8,7 +8,7 @@ ez_40 is a tier 1 lock created by the HALPERYON SYSTEMS corporation.
 
 ### Stats
 
-This upgrade has no additional stats and only spawns at 'kiddie' rarity.
+This upgrade has no additional stats and only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/l0cket.mdx
+++ b/docs/upgrades/locks/l0cket.mdx
@@ -8,7 +8,7 @@ l0cket is a tier 1 [[lock]] created by the NUUTEC SECURITY SYSTEMS corporation.
 
 ## Stats
 
-l0cket includes one additional stat called 'count' which determines the range of solutions a given l0cket will accept. The lock spawns at rarities, noob, kiddie, and h4x0r.
+l0cket includes one additional stat called 'count' which determines the range of solutions a given l0cket will accept. The lock spawns at rarities, ((%0noob%)), ((%1kiddie%)), and ((%2h4x0r%)).
 
 ## Behavior
 

--- a/docs/upgrades/locks/w4rn.mdx
+++ b/docs/upgrades/locks/w4rn.mdx
@@ -8,7 +8,7 @@ w4rn is a tier 1 lock created by the ARCHAIC LABS corporation.
 
 ## Stats
 
-This upgrade has no additional stats and only spawns at 'kiddie' rarity.
+This upgrade has no additional stats and only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/locks/w4rn_er.mdx
+++ b/docs/upgrades/locks/w4rn_er.mdx
@@ -8,7 +8,7 @@ w4rn is a tier 1 lock.
 
 ### Stats
 
-w4rn_er has no additional stats and only spawns at 'kiddie' rarity.
+w4rn_er has no additional stats and only spawns at '((%1kiddie%))' rarity.
 
 ## Behavior
 

--- a/docs/upgrades/other/w4rn_message.mdx
+++ b/docs/upgrades/other/w4rn_message.mdx
@@ -4,7 +4,7 @@ title: w4rn_message
 
 > sys.w4rn_message allows you to change the message in Archaic Labs' w4rn upgrade.
 
-w4rn_message is a tier 1 upgrade. It spawns at 'noob', 'kiddie' and 'h4x0r' rarities.
+w4rn_message is a tier 1 upgrade. It spawns at '((%0noob%))', '((%1kiddie%))' and '((%2h4x0r%))' rarities.
 
 ## Behavior
 

--- a/docs/upgrades/scavenger/transfer_v1.mdx
+++ b/docs/upgrades/scavenger/transfer_v1.mdx
@@ -4,7 +4,7 @@ title: transfer_v1
 
 > sys.xfer_gc_from allows you to transfer money out of a compromised system.
 
-transfer_v1 is a tier 2 upgrade. It spawns at 'kiddie', 'h4x0r' and 'h4rdc0r3' rarities.
+transfer_v1 is a tier 2 upgrade. It spawns at '((%1kiddie%))', '((%2h4x0r%))' and '((%3h4rdc0r3%))' rarities.
 
 ## Stats
 


### PR DESCRIPTION
### Problem

Rarity names currently do not stand out on wiki pages, and do not have self-evident examples of what the rarity names correspond to that players are more familiar with ("green", "blue" etc)

### Context

This PR ran `sed` over the rarity names and gave 'em appropriate colors.