### PR TITLE
add missing lock links

### DIFF
--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -4,7 +4,7 @@ title: c003
 
 > c003 from CORE. Additional complexity, additional cost.
 
-c003 is a tier 1 lock created by the CORE corporation.
+c003 is a tier 1 [[lock]] created by the CORE corporation.
 
 ## Stats
 


### PR DESCRIPTION
### Problem

a few wiki links for word 'lock' missing in docs/upgrades/locks
