### PR TITLE
'{ => y}our lockstack' in glossary.mdx

### DIFF
--- a/docs/guides/new_players/glossary.mdx
+++ b/docs/guides/new_players/glossary.mdx
@@ -87,7 +87,7 @@ An upgrade that defends your system. Common examples are [[ez_21]], [[ez_35]], e
 
 ### lock rotation
 
-A process that happens approximately every hour for most users, where your locks are re-evaluated. This is the only time that changes to our lockstack are noticed. Even with no changes, the answers for your locks are re-randomized every lock rotation.
+A process that happens approximately every hour for most users, where your locks are re-evaluated. This is the only time that changes to your lockstack are noticed. Even with no changes, the answers for your locks are re-randomized every lock rotation.
 
 ### lockstack
 


### PR DESCRIPTION

### Problem

This pronoun is misaligned with the rest of the glossary entry.
Likely a copy/paste error.