### PR TITLE
fix(upgrades/locks/c003): fix triads and color order

### DIFF
--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -54,7 +54,7 @@ Connection terminated.
 
 The (( %Nc003% )) argument expects one of eight colors. (( %Nc003% )) is a string.
 
-Possible colors are: green, yellow, orange, purple, cyan, lime, red, blue
+Possible colors are: green, lime, yellow, orange, red, purple, blue, cyan
 
 </details>
 
@@ -68,12 +68,13 @@ The (( %Nc003_triad_1% )) and (( %Nc003_triad_2% )) arguments are the [color tri
 | c003   | c003_triad_1 | c003_triad_2 |
 | :----- | :----------: | -----------: |
 | green  |    orange    |       purple |
+| lime   |     red      |         blue |
 | yellow |    purple    |         cyan |
 | orange |     blue     |        green |
-| purple |    green     |       yellow |
-| cyan   |    yellow    |          red |
-| lime   |     red      |         blue |
 | red    |     cyan     |         lime |
-| blue   |     lime     |          red |
+| purple |    green     |       yellow |
+| blue   |     lime     |       orange |
+| cyan   |    yellow    |          red |
+
 
 </details>

--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -76,5 +76,4 @@ The (( %Nc003_triad_1% )) and (( %Nc003_triad_2% )) arguments are the [color tri
 | blue   |     lime     |       orange |
 | cyan   |    yellow    |          red |
 
-
 </details>


### PR DESCRIPTION
### Problem
The c003_triad_2 for color blue was incorrect. The colors on the c003 page are also in the wrong order.
