### PR TITLE
Colorising and fixing up the trust script pages

### DIFF
--- a/docs/scripting/trust_scripts/accts.balance.mdx
+++ b/docs/scripting/trust_scripts/accts.balance.mdx
@@ -1,8 +1,9 @@
 ---
 title: accts.balance
+description: "Returns the user's current GC balance"
 ---
 
-accts.balance returns the user's current GC balance
+((accts.balance)) returns the user's current ((%CGC%)) balance
 
 ### Security Level
 
@@ -30,7 +31,7 @@ No known parameters.
 
 #### CLI
 
-On the CLI accts.balance returns a GC string
+On the CLI ((accts.balance)) returns a ((%CGC%)) string
 
 ```
 >>accts.balance

--- a/docs/scripting/trust_scripts/accts.balance_of_owner.mdx
+++ b/docs/scripting/trust_scripts/accts.balance_of_owner.mdx
@@ -1,8 +1,9 @@
 ---
 title: accts.balance_of_owner
+description: "Returns the script owner's GC balance"
 ---
 
-When called as a subscript in a script that is hosted by one player, it allows the balance of the script owner to be seen by a different user running the script.
+When called as a subscript in a script that is hosted by one player, ((accts.balance_of_owner)) allows the balance of the script owner to be seen by a different user running the script.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/accts.transactions.mdx
+++ b/docs/scripting/trust_scripts/accts.transactions.mdx
@@ -1,8 +1,9 @@
 ---
 title: accts.transactions
+description: "Returns a log of the user's transactions"
 ---
 
-accts.transactions returns a log of the user's transactions.
+((accts.transactions)) returns a log of the user's transactions.
 
 ### Security Level
 
@@ -26,23 +27,23 @@ accts.transactions
 
 #### count
 
-The 'count' argument allows a user to specify the number of transactions to be returned.
+The '((%Ncount%))' argument allows a user to specify the number of transactions to be returned.
 
 #### start
 
-The 'start' argument offsets the beginning of the list of transactions to the desired position. Can be used in combination with 'count'.
+The '((%Nstart%))' argument offsets the beginning of the list of transactions to the desired position. Can be used in combination with '((%Ncount%))'.
 
 #### to
 
-The 'to' argument filters transactions that are sent to a specific username.
+The '((%Nto%))' argument filters transactions that are sent to a specific username.
 
 #### from
 
-The 'from' argument filters transactions that are sent from a specific username.
+The '((%Nfrom%))' argument filters transactions that are sent from a specific username.
 
 #### script
 
-The 'script' argument filters transactions by the specific script which sent them.
+The '((%Nscript%))' argument filters transactions by the specific script which sent them.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to.mdx
@@ -1,8 +1,9 @@
 ---
 title: accts.xfer_gc_to
+description: "Sends GC to a specified target"
 ---
 
-accts.xfer_gc_to sends GC from the user running the script, to the target specified by the script.
+((accts.xfer_gc_to)) sends ((%CGC%)) from the user running the script, to the target specified by the script.
 
 ### Security Level
 
@@ -26,15 +27,15 @@ accts.xfer_gc_to { to: "trust", amount: "1M234K567GC" }
 
 #### to (required)
 
-The 'to' argument specifies the target of the transaction. accts.xfer_gc_to (and accts.xfer_gc_to_caller) have a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user `trust`
+The '((%Nto%))' argument specifies the target of the transaction. ((accts.xfer_gc_to)) (and [[accts.xfer_gc_to_caller:((accts.xfer_gc_to_caller))]]) have a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user ((%Ctrust%))
 
 #### amount (required)
 
-The 'amount' argument specifies the amount of GC to be sent. Max transfer limit in a single accts.xfer_gc_to execution is 32BGC.
+The '((%Namount%))' argument specifies the amount of ((%CGC%)) to be sent. Max transfer limit in a single ((accts.xfer_gc_to)) execution is ((32BGC)).
 
 #### memo (optional)
 
-The 'memo' argument attaches a memo to the transaction. The 'memo' can be up to 50 characters long.
+The '((%Nmemo%))' argument attaches a memo to the transaction. The ((%Nmemo%)) can be up to 50 characters long.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -1,8 +1,11 @@
 ---
 title: accts.xfer_gc_to_caller
+description: "Sends GC to the script caller"
 ---
 
-accts.xfer_gc_to_caller allows a script to send GC to the caller of the script. accts.xfer_gc_to_caller (and accts.xfer_gc_to) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user `trust`
+((accts.xfer_gc_to_caller)) allows a script to send GC to the caller of the script. 
+
+((accts.xfer_gc_to_caller)) (and [[accts.xfer_gc_to:((accts.xfer_gc_to))]] ) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user ((%Ctrust%)).
 
 ### Security level
 
@@ -26,11 +29,11 @@ accts.xfer_gc_to_caller
 
 #### amount (required)
 
-The 'amount' argument specifies the amount of GC to send. Max transfer limit in a single accts.xfer_gc_to_caller execution is 32BGC.
+The '((%Namount%))' argument specifies the amount of ((%CGC%)) to send. Max transfer limit in a single ((accts.xfer_gc_to_caller)) execution is ((32BGC)).
 
 #### memo (optional)
 
-The 'memo' argument specifies a memo up to 50 characters long.
+The '((%Nmemo%))' argument specifies a memo up to 50 characters long.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
+++ b/docs/scripting/trust_scripts/accts.xfer_gc_to_caller.mdx
@@ -3,7 +3,7 @@ title: accts.xfer_gc_to_caller
 description: "Sends GC to the script caller"
 ---
 
-((accts.xfer_gc_to_caller)) allows a script to send GC to the caller of the script. 
+((accts.xfer_gc_to_caller)) allows a script to send GC to the caller of the script.
 
 ((accts.xfer_gc_to_caller)) (and [[accts.xfer_gc_to:((accts.xfer_gc_to))]] ) has a ratelimit of 5 transactions to the same recipient in 20 seconds, excluding the user ((%Ctrust%)).
 

--- a/docs/scripting/trust_scripts/autos.reset.mdx
+++ b/docs/scripting/trust_scripts/autos.reset.mdx
@@ -1,8 +1,9 @@
 ---
 title: autos.reset
+description: "Resets the caller's autocompletes"
 ---
 
-autos.reset clears out all of a user's autocompletes.
+((autos.reset)) clears out all of the caller's autocompletes.
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/chats.channels.mdx
+++ b/docs/scripting/trust_scripts/chats.channels.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.channels
+description: "Gets all of the channels the caller is in"
 ---
 
-chats.channels returns all the channels a user is in currently.
+((chats.channels)) returns all the channels a user is in currently.
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/chats.create.mdx
+++ b/docs/scripting/trust_scripts/chats.create.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.create
+description: "Creates a custom chat channel"
 ---
 
-chats.create allows a user to create a custom chat channel. This channel can optionally be password protected. The channel will delete automatically when all users leave.
+((chats.create)) allows a user to create a custom chat channel. This channel can optionally be password protected. The channel will delete automatically when all users leave.
 
 ### Security level
 
@@ -26,11 +27,11 @@ chats.create { name: "example_channel", password: "examplepass" }
 
 #### name (required)
 
-The 'name' argument specifies the name of the channel up to 50 characters long.
+The '((%Nname%))' argument specifies the name of the channel up to 50 characters long.
 
 #### password (optional)
 
-The 'password' argument specifies the channel password.
+The '((%Npassword%))' argument specifies the channel password.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/chats.join.mdx
+++ b/docs/scripting/trust_scripts/chats.join.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.join
+description: "Joins a specified channel"
 ---
 
-chats.join allows a user to join a specified channel.
+((chats.join)) allows a user to join a specified channel.
 
 ### Security level
 
@@ -26,7 +27,7 @@ chats.join { channel: "example_channel" }
 
 #### channel (required)
 
-The 'channel' argument specifies which channel to join.
+The '((%Nchannel%))' argument specifies which channel to join.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/chats.leave.mdx
+++ b/docs/scripting/trust_scripts/chats.leave.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.leave
+description: "Leaves a specified channel"
 ---
 
-chats.leave allows a user to leave a specified channel.
+((chats.leave)) allows a user to leave a specified channel.
 
 ### Security level
 
@@ -26,7 +27,7 @@ chats.leave { channel: "example_channel" }
 
 #### channel (required)
 
-The 'channel' argument specifies which chat channel to leave.
+The '((%Nchannel%))' argument specifies which chat channel to leave.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/chats.send.mdx
+++ b/docs/scripting/trust_scripts/chats.send.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.send
+description: "Sends a message to a specified channel"
 ---
 
-chats.send allows a user to send a message to a specified channel.
+((chats.send)) allows a user to send a message to a specified channel.
 
 ### Security level
 
@@ -26,11 +27,11 @@ chats.send { channel: "example_channel", msg: "this is a message" }
 
 #### channel (required)
 
-The 'channel' argument specifies the channel in which to send a message.
+The '((%Nchannel%))' argument specifies the channel in which to send a message.
 
 #### message (required)
 
-The 'message' argument specifies the message to be sent, up to 1000 characters and 10 lines.
+The '((%Nmessage%))' argument specifies the message to be sent, up to 1000 characters and 10 lines.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/chats.tell.mdx
+++ b/docs/scripting/trust_scripts/chats.tell.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.tell
+description: "Sends a private message to a specified user"
 ---
 
-chats.tell allows a user to send a private message to another user.
+((chats.tell)) allows a user to send a private message to another user.
 
 ### Security level
 
@@ -26,11 +27,11 @@ chats.tell { to: "user", msg: "this is a private message" }
 
 #### to (required)
 
-The 'to' argument specifies the user to send a message to.
+The '((%Nto%))' argument specifies the user to send a message to.
 
 #### msg (required)
 
-The 'msg' argument specifies the private message to be sent.
+The '((%Nmsg%))' argument specifies the private message to be sent.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/chats.users.mdx
+++ b/docs/scripting/trust_scripts/chats.users.mdx
@@ -27,7 +27,7 @@ chats.users { channel: "example_channel" }
 
 #### channel (required)
 
-The '((%Nchannel%))' argument specifies the channel to be checked. 
+The '((%Nchannel%))' argument specifies the channel to be checked.
 
 Note: a user must be in the specified channel in order to see user details of the channel.
 

--- a/docs/scripting/trust_scripts/chats.users.mdx
+++ b/docs/scripting/trust_scripts/chats.users.mdx
@@ -1,8 +1,9 @@
 ---
 title: chats.users
+description: "Shows which users are present in a specified channel"
 ---
 
-chats.users allows a user to see which users are present in a specified channel. Users in the channel with recent activity are indicated by an asterisk.
+((chats.users)) allows a user to see which users are present in a specified channel. Users in the channel with recent activity are indicated by an asterisk.
 
 ### Security level
 
@@ -26,7 +27,9 @@ chats.users { channel: "example_channel" }
 
 #### channel (required)
 
-The 'channel' argument specifies the channel to be checked. Note: a user must be in the specified channel in order to see user details of the channel.
+The '((%Nchannel%))' argument specifies the channel to be checked. 
+
+Note: a user must be in the specified channel in order to see user details of the channel.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.create.mdx
+++ b/docs/scripting/trust_scripts/corps.create.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.create
+description: "Creates a player corporation, for 1BGC"
 ---
 
-corps.create allows a user to create a player corporation for the cost of 1BGC.
+((corps.create)) allows a user to create a player corporation for the cost of ((1BGC)).
 
 ### Security level
 
@@ -26,11 +27,11 @@ corps.create { name: "example_corp", confirm: true }
 
 #### name (required)
 
-The 'name' argument specifies the name of the new player corporation.
+The '((%Nname%))' argument specifies the name of the new player corporation.
 
 #### confirm (required)
 
-The 'confirm' argument confirms creation of new player corporation.
+The '((%Nconfirm%))' argument confirms creation of new player corporation.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.hire.mdx
+++ b/docs/scripting/trust_scripts/corps.hire.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.hire
+description: "Hires another user to a player corporation"
 ---
 
-corps.hire allows a player corporation owner or admin to hire another user.
+((corps.hire)) allows a player corporation owner or admin to hire another user.
 
 ### Security level
 
@@ -26,7 +27,7 @@ corps.hire { name: "example_user" }
 
 #### name (required)
 
-The 'name' argument specifies the user to be hired.
+The '((%Nname%))' argument specifies the user to be hired.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.manage.mdx
+++ b/docs/scripting/trust_scripts/corps.manage.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.manage
+description: "Manage various administrative aspects of a corp"
 ---
 
-corps.manage allows a player corporation owner or admin to manage corp members with actions including promoting members to admin, demoting members from admin, and firing members.
+((corps.manage)) allows a player corporation owner or admin to manage corp members with actions including promoting members to admin, demoting members from admin, and firing members.
 
 ### Security level
 
@@ -26,12 +27,12 @@ corps.manage { command: "list" }
 
 #### command (required)
 
-The 'command' key takes several values which will be returned to the screen using corps.manage with no arguments. The possible values include:
+The '((%Ncommand%))' key takes several values which will be returned to the screen using ((corps.manage)) with no arguments. The possible values include:
 
-- list
-- demote
-- promote
-- fire
+- ((%Vlist%))
+- ((%Vdemote%))
+- ((%Vpromote%))
+- ((%Vfire%))
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.offers.mdx
+++ b/docs/scripting/trust_scripts/corps.offers.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.offers
+description: "View offers from player corporations"
 ---
 
-corps.offers allows a user to view hire offers from player corporations.
+((corps.offers)) allows a user to view hire offers from player corporations.
 
 ### Security level
 
@@ -26,7 +27,7 @@ corps.offers
 
 #### accept
 
-The 'accept' argument is used to specify which corporation to join. It expects a string.
+The '((%Naccept%))' argument is used to specify which corporation to join. It expects a string.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.quit.mdx
+++ b/docs/scripting/trust_scripts/corps.quit.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.quit
+description: "Leave a player corporation"
 ---
 
-corps.quit allows a player corporation member remove themselves from the player corporation.
+((corps.quit)) allows a player corporation member remove themselves from the player corporation.
 
 ### Security level
 
@@ -26,7 +27,7 @@ corps.quit { confirm: true }
 
 #### confirm (required)
 
-The 'confirm' argument confirms quitting the player corporation.
+The '((%Nconfirm%))' argument confirms quitting the player corporation.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/corps.top.mdx
+++ b/docs/scripting/trust_scripts/corps.top.mdx
@@ -1,8 +1,9 @@
 ---
 title: corps.top
+description: "Returns the top 10 player coporations by total GC"
 ---
 
-corps.top returns the top 10 player corporations by total GC.
+((corps.top)) returns the domain's top 10 player corporations by total ((%CGC%)).
 
 ### Security level
 

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -1,8 +1,9 @@
 ---
 title: escrow.charge
+description: "Consensually charges a caller GC to use a script"
 ---
 
-escrow.charge is a secure transaction system which can be used to sell access to a script.
+((escrow.charge)) is a secure transaction system which can be used to sell access to a script.
 
 ### Security Level
 
@@ -26,11 +27,11 @@ escrow.charge { cost: "1GC", is_unlim: true }
 
 #### cost (required)
 
-The 'cost' argument specifies a script-runs' escrow cost.
+The '((%Ncost%))' argument specifies a script-runs' escrow cost.
 
 #### is_unlim (required)
 
-The 'is_unlim' argument specifies whether the escrow cost is per-run, or unlimited access for a one-time-cost.
+The '((%Nis_unlim%))' argument specifies whether the escrow cost is per-run, or unlimited access for a one-time-cost.
 
 ### Return
 
@@ -48,7 +49,7 @@ if (result) return result;
 
 #### Script
 
-Running a script which includes escrow.charge on the user who hosts it will execute the script as normal, bypassing the cost requirement and escrow return. If a script which includes escrow.charge is run by any other user, the script will return a token, represented as a 6 character alpha-numeric string:
+Running a script which includes ((escrow.charge)) on the user who hosts it will execute the script as normal, bypassing the cost requirement and escrow return. If a script which includes ((escrow.charge)) is run by any other user, the script will return a token, represented as a 6 character alpha-numeric string:
 
 ```
 Failure
@@ -70,4 +71,4 @@ function(context, args)
 }
 ```
 
-If this script is run with no arguments, it will return an escrow token. If the escrow is confirmed, the script will return a smiley face. This script is set to require an escrow confirmation for each run. Changing the 'is_unlim' argument's value to `true` makes this a one-time-fee.
+If this script is run with no arguments, it will return an escrow token. If the escrow is confirmed, the script will return a smiley face. This script is set to require an escrow confirmation for each run. Changing the '((%Nis_unlim%))' argument's value to ((%Vtrue%)) makes this a one-time-fee.

--- a/docs/scripting/trust_scripts/escrow.confirm.mdx
+++ b/docs/scripting/trust_scripts/escrow.confirm.mdx
@@ -1,8 +1,9 @@
 ---
 title: escrow.confirm
+description: "Validates an escrow.charge payment"
 ---
 
-escrow.confirm validates the escrow.charge payment using the token provided.
+((escrow.confirm)) validates an [[escrow.charge:((escrow.charge))]] payment using the token provided.
 
 ### Security Level
 
@@ -24,11 +25,11 @@ Cannot be called as a subscript.
 
 #### i (required)
 
-The 'i' argument specifies the token
+The '((%Ni%))' argument specifies the token
 
 #### confirm (required)
 
-The 'confirm' argument is a boolean confirmation of the escrow validation.
+The '((%Nconfirm%))' argument is a boolean confirmation of the escrow validation.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/escrow.stats.mdx
+++ b/docs/scripting/trust_scripts/escrow.stats.mdx
@@ -1,8 +1,9 @@
 ---
 title: escrow.stats
+description: "Returns the caller's escrow sales stats"
 ---
 
-escrow.stats returns an information object with stats regarding escrow.charge inclusive scripts.
+((escrow.stats)) returns an information object with stats regarding [[escrow.charge:((escrow.charge))]] inclusive scripts.
 
 ### Security Level
 
@@ -59,7 +60,7 @@ Returns an object.
 
 ## Example
 
-Using escrow.stats in a script allows access to the objects' individual properties, such as `scripts`.
+Using ((escrow.stats)) in a script allows access to the objects' individual properties, such as `scripts`.
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/gui.chats.mdx
+++ b/docs/scripting/trust_scripts/gui.chats.mdx
@@ -1,8 +1,9 @@
 ---
 title: gui.chats
+description: "Dictates the behavior of chat in the main terminal/chat window"
 ---
 
-gui.chats dictates the behavior of chat in the main terminal window, and/or, in the chat window.
+((gui.chats)) dictates the behavior of chat in the main terminal window, and/or, in the chat window.
 
 ### Security Level
 
@@ -23,19 +24,19 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-One argument is required, either shell, or chat. If no arguments are provided, the script will return a Failure and usage information. The default values are both set to true.
+One argument is required, either ((%Nshell%)) or ((%Nchat%)). If no arguments are provided, the script will return a ((%DFailure%)) and usage information. The default values are both set to ((%Vtrue%)).
 
 #### shell
 
-The 'shell' argument dictates if chat appears in the main window or not using a boolean (true/false).
+The '((%Nshell%))' argument dictates if chat appears in the main window or not using a boolean (((%Vtrue%))/((%Vfalse%))).
 
 #### chat
 
-The 'chat' argument dictates if chat appears in the main window or not using a boolean (true/false).
+The '((%Nchat%))' argument dictates if chat appears in the main window or not using a boolean (((%Vtrue%))/((%Vfalse%))).
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/gui.quiet.mdx
+++ b/docs/scripting/trust_scripts/gui.quiet.mdx
@@ -1,8 +1,9 @@
 ---
 title: gui.quiet
+description: "Quietens a user's chats in the terminal"
 ---
 
-gui.quiet prevents a user's chats from appearing in the terminal.
+((gui.quiet)) prevents a user's chats from appearing in the terminal.
 
 ### Security Level
 
@@ -22,23 +23,23 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-At least one argument is required. If no arguments are provided, gui.quiet will return a Failure object and usage information.
+At least one argument is required. If no arguments are provided, ((gui.quiet)) will return a ((%DFailure%)) object and usage information.
 
 #### add (optional)
 
-The 'add' argument takes a username as a string. Chats from the username input as a value of the 'add' argument will be muted in the terminal windows.
+The '((%Nadd%))' argument takes a username as a string. Chats from the username input as a value of the '((%Nadd%))' argument will be muted in the terminal windows.
 
 #### remove (optional)
 
-The 'remove' argument takes a username as a string. Chats from the username input as a value of the 'remove' argument will appear in the terminal windows.
+The '((%Nremove%))' argument takes a username as a string. Chats from the username input as a value of the '((%Nremove%))' argument will appear in the terminal windows.
 
 #### list (optional)
 
-The 'list' argument takes a boolean (true/false). If the value is set to true, all muted usernames will be listed.
+The '((%Nlist%))' argument takes a boolean (true/false). If the value is set to true, all muted usernames will be listed.
 
 #### clear (optional)
 
-The 'clear' argument takes a boolean (true/false). If the value is set to true, all previously muted usernames will be unmuted.
+The '((%Nclear%))' argument takes a boolean (true/false). If the value is set to true, all previously muted usernames will be unmuted.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/gui.size.mdx
+++ b/docs/scripting/trust_scripts/gui.size.mdx
@@ -1,8 +1,9 @@
 ---
 title: gui.size
+description: "Changes text size"
 ---
 
-gui.size specifies text size in the terminal window.
+((gui.size)) specifies text size in the terminal window.
 
 ### Security Level
 
@@ -24,11 +25,11 @@ Cannot be called as a subscript.
 
 #### i (required)
 
-the 'i' argument specifies the text size, as a number from -20 to 20. The default value is set to 0.
+the '((%Ni%))' argument specifies the text size, as a number from ((%V-20%)) to ((%V20%)). The default value is set to ((%V0%)).
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/gui.vfx.mdx
+++ b/docs/scripting/trust_scripts/gui.vfx.mdx
@@ -1,8 +1,9 @@
 ---
 title: gui.vfx
+description: "Controls client video effects settings"
 ---
 
-gui.vfx controls the video effects settings for the terminal window.
+((gui.vfx)) controls the video effects settings for the terminal window.
 
 ### Security Level
 
@@ -22,7 +23,7 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-At least one argument is required. If no arguments are provided, gui.vfx will return a Failure object and usage information. All parameters take a number ranging from 0 to 11. The default values are:
+At least one argument is required. If no arguments are provided, ((gui.vfx)) will return a Failure object and usage information. All parameters take a number ranging from ((%V0%)) to ((%V11%)). The default values are:
 
 ```
 gui.vfx { bloom: 5, noise: 5, scan: 5, bend: 4 }
@@ -30,23 +31,23 @@ gui.vfx { bloom: 5, noise: 5, scan: 5, bend: 4 }
 
 #### bloom
 
-The 'bloom' argument specifies the intensity of the bloom effect around text characters.
+The '((%Nbloom%))' argument specifies the intensity of the bloom effect around text characters.
 
 #### noise
 
-The 'noise' argument specifies the intensity of the noise effect on the screen.
+The '((%Nnoise%))' argument specifies the intensity of the noise effect on the screen.
 
 #### scan
 
-The 'scan' argument specifies the intensity of the scan lines effect on the screen.
+The '((%Nscan%))' argument specifies the intensity of the scan lines effect on the screen.
 
 #### bend
 
-The 'bend' argument specifies the intensity of the bend effect on the screen.
+The '((%Nbend%))' argument specifies the intensity of the bend effect on the screen.
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/gui.vol.mdx
+++ b/docs/scripting/trust_scripts/gui.vol.mdx
@@ -1,8 +1,9 @@
 ---
 title: gui.vol
+description: "Controls the game volume"
 ---
 
-gui.vol controls the game volume.
+((gui.vol)) controls the game volume.
 
 ### Security Level
 
@@ -22,19 +23,19 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-At least one argument is required. If no arguments are provided, gui.vol will return a Failure object and usage instructions. All argument values are numbers ranging from 0 to 11. The default values are 11.
+At least one argument is required. If no arguments are provided, ((gui.vol)) will return a ((%DFailure%)) object and usage instructions. All argument values are numbers ranging from ((%V0%)) to ((%V11%)). The default values are ((%V11%)).
 
 #### bgm
 
-The 'bgm' argument specifies the music volume.
+The '((%Nbgm%))' argument specifies the music volume.
 
 #### sfx
 
-The 'sfx' argument specifies the sound effects volume.
+The '((%Nsfx%))' argument specifies the sound effects volume.
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/kernel.hardline.mdx
+++ b/docs/scripting/trust_scripts/kernel.hardline.mdx
@@ -19,7 +19,7 @@ kernel.hardline
 
 ### Script
 
-:::note 
+:::note
 ((kernel.hardline)) can only be called as a subscript by [[bot_brains]].
 :::
 

--- a/docs/scripting/trust_scripts/kernel.hardline.mdx
+++ b/docs/scripting/trust_scripts/kernel.hardline.mdx
@@ -1,8 +1,9 @@
 ---
 title: kernel.hardline
+description: "Engages hardline mode"
 ---
 
-kernel.hardline enters hardline mode and allows connection attempts between systems.
+((kernel.hardline)) enters hardline mode and allows connection attempts between systems.
 
 ### Security Level
 
@@ -18,7 +19,9 @@ kernel.hardline
 
 ### Script
 
-Note: kernel.hardline can only be called as a subscript by [[bot_brains]].
+:::note 
+((kernel.hardline)) can only be called as a subscript by [[bot_brains]].
+:::
 
 ```
 #ls.kernel.hardline({ activate: true })
@@ -28,15 +31,15 @@ Note: kernel.hardline can only be called as a subscript by [[bot_brains]].
 
 #### dc (optional)
 
-The 'dc' argument disconnects from hardline mode when its value is set to true.
+The '((%Ndc%))' argument disconnects from hardline mode when its value is set to ((%Vtrue%)).
 
 #### activate
 
-The 'activate' argument is required for [[bot_brains]] to hardline.
+The '((%Nactivate%))' argument is required for [[bot_brains]] to hardline.
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/market.browse.mdx
+++ b/docs/scripting/trust_scripts/market.browse.mdx
@@ -1,8 +1,9 @@
 ---
 title: market.browse
+description: "Shows upgrades currently for sale on the market"
 ---
 
-market.browse shows upgrades currently for sale on the marketplace.
+((market.browse)) shows upgrades currently for sale on the marketplace.
 
 ### Security Level
 
@@ -24,51 +25,51 @@ market.browse { tier: 1, seller: "trust", rarity: 0 }
 
 ### Parameters
 
-At least one argument is required. If no arguments are input, market.browse will return a Failure object and detailed usage information. All arguments are optional. Any parameter that can take a number can also take MongoDB query conditionals, e.g. `chars: { $gte: 2000 }`.
+At least one argument is required. If no arguments are input, ((market.browse)) will return a ((%DFailure%)) object and detailed usage information. All arguments are optional. Any parameter that can take a number can also take MongoDB query conditionals, e.g. `chars: { $gte: 2000 }`.
 
 #### tier
 
-The 'tier' argument takes a number and specifies the tier of upgrades to be shown.
+The '((%Ntier%))' argument takes a number and specifies the tier of upgrades to be shown.
 
 #### seller
 
-The 'seller' argument takes a username as a string and specifies the seller, for example to filter upgrades sold by TRUST.
+The '((%Nseller%))' argument takes a username as a string and specifies the seller, for example to filter upgrades sold by TRUST.
 
 #### listed_before
 
-The 'listed_before" argument takes a Unix timestamp, e.g. `1490286018.35423`.
+The '((%Nlisted_before%))" argument takes a Unix timestamp, e.g. `1490286018.35423`.
 
 #### listed_after
 
-The 'listed_after" argument takes a Unix timestamp, e.g. `1490286018.35423`.
+The '((%Nlisted_after%))" argument takes a Unix timestamp, e.g. `1490286018.35423`.
 
 #### rarity
 
-The 'rarity' argument takes a number ranging from 0 to 5 and specifies the rarity of upgrades to be shown.
+The '((%Nrarity%))' argument takes a number ranging from 0 to 5 and specifies the rarity of upgrades to be shown.
 
 #### cost
 
-The 'cost' argument can take a GC string, a number, or MongoDB query conditionals, e.g. `cost: { $lte: 500000 }`
+The '((%Ncost%))' argument can take a GC string, a number, or MongoDB query conditionals, e.g. `cost: { $lte: 500000 }`
 
 #### name
 
-The 'name' argument takes a string and specifies the name of upgrades to be shown.
+The '((%Nname%))' argument takes a string and specifies the name of upgrades to be shown.
 
 #### type
 
-The 'type' argument takes a string and filters by upgrade type, e.g. `type: "lock"`.
+The '((%Ntype%))' argument takes a string and filters by upgrade type, e.g. ((type: "lock")).
 
 #### class
 
-The 'class' argument takes a string and filters by upgrade class, e.g. `class: "architect"`
+The '((%Nclass%))' argument takes a string and filters by upgrade class, e.g. ((class: "architect")).
 
 #### chars
 
-The 'chars' argument takes a number or MongoDB query conditional, `chars: { $gte: 2000 }`
+The '((%Nchars%))' argument takes a number or MongoDB query conditional, `chars: { $gte: 2000 }`
 
 #### i
 
-The 'i' argument takes a market token as a string and returns detailed information about a market upgrade.
+The '((%Ni%))' argument takes a market token as a string and returns detailed information about a market upgrade.
 
 ### Return
 
@@ -76,7 +77,7 @@ Returns an object.
 
 #### CLI
 
-Once filtered, market.browse will return token codes, represented by 6 character alpha-numeric strings which can be used to purchase upgrades.
+Once filtered, ((market.browse)) will return token codes, represented by 6 character alpha-numeric strings which can be used to purchase upgrades.
 
 ```
 >>market.browse { tier: 1, seller: "trust", rarity: 0, name: "ez_21" }
@@ -147,7 +148,7 @@ Returning from a script will give more detailed output:
 
 ## Example
 
-An example use of the function, in code, or script, in client and code
+This script returns all market listings for tier-1 upgrades named [[ez_21]], being sold by ((%Ctrust%))
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/market.buy.mdx
+++ b/docs/scripting/trust_scripts/market.buy.mdx
@@ -1,8 +1,9 @@
 ---
 title: market.buy
+description: "Purchases upgrades listed on the market"
 ---
 
-market.buy is a secure purchase system which uses 8 character alpha-numeric tokens from [[market.browse]] to purchase upgrades from the marketplace.
+((market.buy)) is a secure purchase system which uses 8 character alpha-numeric tokens from [[market.browse:((market.browse))]] to purchase upgrades from the marketplace.
 
 ### Security Level
 
@@ -10,7 +11,7 @@ MIDSEC
 
 ## Syntax
 
-market.buy takes a market token as a string and requires that the value of the 'confirm' parameter be set to true.
+((market.buy)) takes a market token as a string and requires that the value of the '((%Nconfirm%))' parameter be set to ((%Vtrue%)).
 
 ### CLI
 
@@ -28,15 +29,15 @@ market.buy { i: "token5" }
 
 #### i (required)
 
-The 'i' argument takes a market token as a string.
+The '((%Ni%))' argument takes a market token as a string.
 
 #### confirm (required)
 
-The 'confirm' argument value must be `true` in order to confirm purchase.
+The '((%Nconfirm%))' argument value must be ((%Vtrue%)) in order to confirm purchase.
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 
@@ -48,7 +49,7 @@ Failure
 invalid token. specify valid token with i:"<token>"
 ```
 
-With valid arguments, confirmation, and enough GC to cover the purchase:
+With valid arguments, confirmation, and enough ((%CGC%)) to cover the purchase:
 
 ```
 >>market.buy { i: "ebwff5", confirm: true }

--- a/docs/scripting/trust_scripts/market.sell.mdx
+++ b/docs/scripting/trust_scripts/market.sell.mdx
@@ -1,8 +1,9 @@
 ---
 title: market.sell
+description: "Creates listings on the market"
 ---
 
-market.sell lists upgrades for sale on the marketplace.
+((market.sell)) lists upgrades for sale on the marketplace.
 
 ### Security Level
 
@@ -24,31 +25,31 @@ market.sell { i: 0, cost: 1000, description: "smokin' deal" }
 
 ### Parameters
 
-market.sell has 2 required parameters, `cost` and `i`. All other parameters are optional.
+((market.sell)) has 2 required parameters, ((%Ncost%)) and ((%Ni%)). All other parameters are optional.
 
 #### i (required)
 
-The 'i' argument takes a number and specifies the inventory index of the upgrade to be listed for sale.
+The '((%Ni%))' argument takes a number and specifies the inventory index of the upgrade to be listed for sale.
 
 #### cost (required)
 
-The 'cost' argument takes a number and specifies the asking price of the upgrade to be listed for sale.
+The '((%Ncost%))' argument takes a number and specifies the asking price of the upgrade to be listed for sale.
 
 #### description (optional)
 
-The 'description' argument takes a string and specifies the description field of the upgrade to be listed for sale.
+The '((%Ndescription%))' argument takes a string and specifies the description field of the upgrade to be listed for sale.
 
 #### count (optional)
 
-The 'count' argument takes a number and specifies how many of the same upgrade should be listed as a stack.
+The '((%Ncount%))' argument takes a number and specifies how many of the same upgrade should be listed as a stack.
 
 #### delist (optional)
 
-The 'delist' argument takes a market token as a string and specifies an upgrade to be taken off the marketplace.
+The '((%Ndelist%))' argument takes a market token as a string and specifies an upgrade to be taken off the marketplace.
 
 #### no_notify (optional)
 
-The 'no_notify" argument takes a boolean. Default value is set to true.
+The '((%Nno_notify%))" argument takes a boolean. Default value is set to ((%Vtrue%)).
 
 ### Return
 

--- a/docs/scripting/trust_scripts/market.stats.mdx
+++ b/docs/scripting/trust_scripts/market.stats.mdx
@@ -1,8 +1,9 @@
 ---
 title: market.stats
+description: "Returns info about the caller's market sales"
 ---
 
-market.stats returns an object containing statistical information about items listed and sold on the market, as well as GC earned from marketplace sales.
+((market.stats)) returns an object containing statistical information about items listed and sold on the market, as well as ((%CGC%)) earned from marketplace sales.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/scripts.fullsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.fullsec.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.fullsec
+description: "Lists FULLSEC sectors and scripts"
 ---
 
-scripts.fullsec lists the FULLSEC sectors.
+((scripts.fullsec)) lists the FULLSEC sectors.
 
 ### Security Level
 
@@ -26,7 +27,7 @@ scripts.fullsec
 
 #### sector
 
-The 'sector' argument specifies the fullsec sector to be shown.
+The '((%Nsector%))' argument specifies the fullsec sector to be shown.
 
 ### Return
 
@@ -41,15 +42,17 @@ No arguments:
 specify & join a sector to see a list of the scripts in that sector.
 ```
 
-The listed sectors are dynamic and will change over time. Running scripts.fullsec on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Running ((scripts.fullsec)) on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
 
 #### Script
 
-The listed sectors are dynamic and will change over time. Calling scripts.fullsec as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Calling ((scripts.fullsec)) as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
 
 ## Example
 
-Note: the example sector may not be a valid sector.
+:::note
+the example sector may not be a valid sector.
+:::
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/scripts.get_access_level.mdx
+++ b/docs/scripting/trust_scripts/scripts.get_access_level.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.get_access_level
+description: "Gets the access level of a script"
 ---
 
-scripts.get_access_level shows information about a scripts' access level. Possible access level indicators include:
+((scripts.get_access_level)) shows information about a script's access level. Possible access level indicators include:
 
 - PUBLIC
 - PRIVATE
@@ -33,13 +34,13 @@ scripts.get_access_level { name: "accts.balance" }
 
 #### name (required)
 
-The 'name' argument specifies which scripts' access level shall be checked.
+The '((%Nname%))' argument specifies which scripts' access level shall be checked.
 
 ### Return
 
 #### CLI
 
-On the CLI scripts.get_access_level returns a string.
+On the CLI ((scripts.get_access_level)) returns a string.
 
 ```
 >>scripts.get_access_level { name: "accts.balance" }
@@ -48,7 +49,7 @@ PUBLIC TRUST
 
 #### Script
 
-Called as a subscript, scripts.get_access_level returns an object.
+Called as a subscript, ((scripts.get_access_level)) returns an object.
 
 ```
 {

--- a/docs/scripting/trust_scripts/scripts.get_level.mdx
+++ b/docs/scripting/trust_scripts/scripts.get_level.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.get_level
+description: "Gets the security level of a script"
 ---
 
-scripts.get_level shows a scripts security level.
+((scripts.get_level)) shows a script's security level.
 
 ### Security Level
 
@@ -26,13 +27,13 @@ scripts.get_level { name: "accts.balance" }
 
 #### name (required)
 
-The 'name' argument specifies which scripts' security level shall be checked.
+The '((%Nname%))' argument specifies which scripts' security level shall be checked.
 
 ### Return
 
 #### CLI
 
-On the CLI, scripts.get_level returns a string.
+On the CLI, ((scripts.get_level)) returns a string.
 
 ```
 >>scripts.get_level { name: "accts.balance" }
@@ -41,7 +42,7 @@ HIGHSEC
 
 #### Script
 
-Called as a subscript, scripts.get_level returns a number.
+Called as a subscript, ((scripts.get_level)) returns a number.
 
 ```
 3

--- a/docs/scripting/trust_scripts/scripts.highsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.highsec.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.highsec
+description: "Lists HIGHSEC sectors and scripts"
 ---
 
-scripts.highsec lists the HIGHSEC sectors.
+((scripts.highsec)) lists the HIGHSEC sectors.
 
 ### Security Level
 
@@ -26,7 +27,7 @@ scripts.highsec
 
 #### sector
 
-The 'sector' argument specifies the HIGHSEC sector to be shown.
+The '((%Nsector%))' argument specifies the HIGHSEC sector to be shown.
 
 ### Return
 
@@ -41,15 +42,17 @@ No arguments:
 specify & join a sector to see a list of the scripts in that sector.
 ```
 
-The listed sectors are dynamic and will change over time. Running scripts.highsec on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Running ((scripts.highsec)) on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
 
 #### Script
 
-The listed sectors are dynamic and will change over time. Calling scripts.highsec as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Calling ((scripts.highsec)) as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
 
 ## Example
 
-Note: the example sector may not be a valid sector.
+:::note
+The example sector may not be a valid sector.
+:::
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/scripts.lowsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.lowsec.mdx
@@ -1,12 +1,13 @@
 ---
 title: scripts.lowsec
+description: "Lists LOWSEC sectors and scripts"
 ---
 
-scripts.lowsec lists the LOWSEC sectors.
+((scripts.lowsec)) lists the LOWSEC sectors.
 
 ### Security Level
 
-lowsec
+LOWSEC
 
 ## Syntax
 
@@ -26,7 +27,7 @@ scripts.lowsec
 
 #### sector
 
-The 'sector' argument specifies the LOWSEC sector to be shown.
+The '((%Nsector%))' argument specifies the LOWSEC sector to be shown.
 
 ### Return
 
@@ -41,15 +42,17 @@ No arguments:
 specify & join a sector to see a list of the scripts in that sector.
 ```
 
-The listed sectors are dynamic and will change over time. Running scripts.lowsec on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Running ((scripts.lowsec)) on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
 
 #### Script
 
-The listed sectors are dynamic and will change over time. Calling scripts.lowsec as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Calling ((scripts.lowsec)) as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
 
 ## Example
 
-Note: the example sector may not be a valid sector.
+:::note
+The example sector may not be a valid sector.
+:::
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/scripts.midsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.midsec.mdx
@@ -1,12 +1,13 @@
 ---
 title: scripts.midsec
+description: "Lists MIDSEC sectors and scripts"
 ---
 
-scripts.midsec lists the MIDSEC sectors.
+((scripts.midsec)) lists the MIDSEC sectors.
 
 ### Security Level
 
-midsec
+MIDSEC
 
 ## Syntax
 
@@ -26,7 +27,7 @@ scripts.midsec
 
 #### sector
 
-The 'sector' argument specifies the MIDSEC sector to be shown.
+The '((%Nsector%))' argument specifies the MIDSEC sector to be shown.
 
 ### Return
 
@@ -41,15 +42,17 @@ No arguments:
 specify & join a sector to see a list of the scripts in that sector.
 ```
 
-The listed sectors are dynamic and will change over time. Running scripts.midsec on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Running ((scripts.midsec)) on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
 
 #### Script
 
-The listed sectors are dynamic and will change over time. Calling scripts.midsec as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Calling ((scripts.midsec)) as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
 
 ## Example
 
-Note: the example sector may not be a valid sector.
+:::note
+The example sector may not be a valid sector.
+:::
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/scripts.nullsec.mdx
+++ b/docs/scripting/trust_scripts/scripts.nullsec.mdx
@@ -1,12 +1,13 @@
 ---
 title: scripts.nullsec
+description: "Lists NULLSEC sectors and scripts"
 ---
 
-scripts.nullsec lists the NULLSEC sectors.
+((scripts.nullsec)) lists the NULLSEC sectors.
 
 ### Security Level
 
-nullsec
+NULLSEC
 
 ## Syntax
 
@@ -26,7 +27,7 @@ scripts.nullsec
 
 #### sector
 
-The 'sector' argument specifies the NULLSEC sector to be shown.
+The '((%Nsector%))' argument specifies the NULLSEC sector to be shown.
 
 ### Return
 
@@ -41,15 +42,17 @@ No arguments:
 specify & join a sector to see a list of the scripts in that sector.
 ```
 
-The listed sectors are dynamic and will change over time. Running scripts.nullsec on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Running ((scripts.nullsec)) on the CLI will return 4 columns of sector names. Specifiying a sector will return the scripts which are currently in that sector.
 
 #### Script
 
-The listed sectors are dynamic and will change over time. Calling scripts.nullsec as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
+The listed sectors are dynamic and will change over time. Calling ((scripts.nullsec)) as a subscript will list one column of sector names by default. Specifiying a sector will return the scripts which are currently in that sector.
 
 ## Example
 
-Note: the example sector may not be a valid sector.
+:::note
+The example sector may not be a valid sector.
+:::
 
 ```js
 function(context, args)

--- a/docs/scripting/trust_scripts/scripts.quine.mdx
+++ b/docs/scripting/trust_scripts/scripts.quine.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.quine
+description: "Outputs the source code of a script"
 ---
 
-scripts.quine outputs the source code of a player-made script.
+((scripts.quine)) outputs the source code of a player-made script.
 
 ### Security Level
 
@@ -12,7 +13,7 @@ FULLSEC
 
 ### CLI
 
-On the CLI, scripts.quine returns a Failure object and usage information.
+On the CLI, ((scripts.quine)) returns a ((%DFailure%)) object and usage information.
 
 ```
 >>scripts.quine
@@ -35,11 +36,11 @@ No known parameters.
 
 #### CLI
 
-On the CLI, scripts.quine returns an object.
+On the CLI, ((scripts.quine)) returns an object.
 
 #### Script
 
-Called as a subscript, scripts.quine returns a string.
+Called as a subscript, ((scripts.quine)) returns a string, consisting of the source code of the calling script.
 
 ```
 :)

--- a/docs/scripting/trust_scripts/scripts.sys.mdx
+++ b/docs/scripting/trust_scripts/scripts.sys.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.sys
+description: "Lists the caller's accessible system scripts"
 ---
 
-scripts.sys lists the available system scripts that can currently be accessed, based on upgrades loaded.
+((scripts.sys)) lists the available system scripts that can currently be accessed, based on upgrades loaded.
 
 ### Security Level
 
@@ -32,7 +33,7 @@ Returns an array.
 
 #### CLI
 
-On the CLI, scripts.sys returns strings formatted in columns.
+On the CLI, ((scripts.sys)) returns strings formatted in columns.
 
 ```
 >>scripts.sys
@@ -44,7 +45,7 @@ sys.expose_upgrade_log
 
 #### Script
 
-Returns the array of strings as a single column by default.
+Returns an array of strings.
 
 ```
 sys.expose_access_log

--- a/docs/scripting/trust_scripts/scripts.trust.mdx
+++ b/docs/scripting/trust_scripts/scripts.trust.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.trust
+descriptions: "Lists the trust scripts"
 ---
 
-scripts.trust lists the TRUST scripts.
+((scripts.trust)) lists the TRUST scripts.
 
 ### Security Level
 
@@ -32,7 +33,7 @@ Returns an array.
 
 #### CLI
 
-On the CLI, scripts.trust returns the array of strings formatted in columns.
+On the CLI, ((scripts.trust)) returns the array of strings formatted in columns.
 
 ```
 >>scripts.trust
@@ -53,7 +54,7 @@ chats.users                gui.vfx                    scripts.nullsec           
 
 #### Script
 
-Called as a subscript, scripts.trust returns the array of strings in a single column by default.
+Called as a subscript, ((scripts.trust)) returns the array of strings in a single column by default.
 
 ## Example
 

--- a/docs/scripting/trust_scripts/scripts.user.mdx
+++ b/docs/scripting/trust_scripts/scripts.user.mdx
@@ -1,8 +1,9 @@
 ---
 title: scripts.user
+description: "Returns the scripts currently hosted on a user"
 ---
 
-scripts.user lists the player-made scripts that are currently hosted (`#up`) on a system.
+((scripts.user)) lists the player-made scripts that are currently hosted (((%C#up%))) on a user.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/sys.access_log.mdx
+++ b/docs/scripting/trust_scripts/sys.access_log.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.access_log
+description: "Returns the user's system access log"
 ---
 
-sys.access_log displays information about connection attempts from other systems, including lock state and breach state rotation.
+((sys.access_log)) displays information about connection attempts from other systems, including lock state and breach state rotation.
 
 ### Security Level
 
@@ -26,19 +27,19 @@ sys.access_log
 
 #### user
 
-The 'user' argument filters access logs to be displayed by username.
+The '((%Nuser%))' argument filters access logs to be displayed by username.
 
 #### run_id
 
-The 'run_id' argument filters access logs to be displayed by specific run ID's.
+The '((%Nrun_id%))' argument filters access logs by specific [[RUN_ID:run ID]]s.
 
 #### count
 
-The 'count' argument specifies the number of access logs to be displayed.
+The '((%Ncount%))' argument specifies the number of access logs to be displayed.
 
 #### start
 
-The 'start' argument offsets the start of the access logs to be displayed.
+The '((%Nstart%))' argument offsets the start of the access logs to be displayed.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.breach.mdx
+++ b/docs/scripting/trust_scripts/sys.breach.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.breach
+description: "Breaches the caller's system"
 ---
 
-sys.breach breaches the caller's system.
+((sys.breach)) breaches the caller's system.
 
 ### Security Level
 
@@ -26,7 +27,7 @@ sys.breach { confirm: true }
 
 #### confirm (required)
 
-The 'confirm' parameter allows execution of sys.breach.
+The '((%Nconfirm%))' parameter confirms execution of ((sys.breach)).
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.cull.mdx
+++ b/docs/scripting/trust_scripts/sys.cull.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.cull
+description: "Destroys specified upgrades"
 ---
 
-sys.cull allows a user to destroy an upgrade specified by the `i` argument.
+((sys.cull)) allows a user to destroy an upgrade specified by the `i` argument.
 
 ### Security Level
 
@@ -36,7 +37,7 @@ sys.cull { i: [ 0, 1, 2 ], confirm: true }
 
 #### i (required)
 
-The 'i' parameter specifies the upgrade(s) to be culled.
+The '((%Ni%))' parameter specifies the upgrade(s) to be culled.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.init.mdx
+++ b/docs/scripting/trust_scripts/sys.init.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.init
+description: "Initializes a system, or upgrades its tier"
 ---
 
-sys.init initializes a system, or upgrades its tier once it is initialized.
+((sys.init)) initializes a system, or upgrades its tier once it is initialized.
 
 ### Security Level
 
@@ -18,19 +19,17 @@ sys.init { confirm: true }
 
 ### Script
 
-```
-#fs.sys.init({ confirm: true })
-```
+Cannot be called as a subscript.
 
 ### Parameters
 
 #### confirm (required)
 
-The 'confirm' parameter allows execution of sys.init.
+The '((%Nconfirm%))' parameter confirms system initialization.
 
 ### Return
 
-Returns a Success or Faliure object.
+Returns a ((%LSuccess%)) or ((%DFaliure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/sys.loc.mdx
+++ b/docs/scripting/trust_scripts/sys.loc.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.loc
+description: "Returns the calling system's loc"
 ---
 
-sys.loc displays a system's [[loc]].
+((sys.loc)) displays the calling system's [[loc]].
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/sys.manage.mdx
+++ b/docs/scripting/trust_scripts/sys.manage.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.manage
+description: "Loads, unloads or reorders upgrades"
 ---
 
-sys.manage allows loading, unloading or reordering upgrades.
+((sys.manage)) allows loading, unloading or reordering upgrades.
 
 ### Security Level
 
@@ -26,15 +27,15 @@ sys.manage
 
 #### unload
 
-The 'unload' argument takes an upgrade index as a number, or an array of numbers with no leading 0s.
+The '((%Nunload%))' argument takes an upgrade index as a number, or an array of numbers with no leading 0s.
 
 #### load
 
-The 'load' argument takes an upgrade index as a number, or an array of numbers with no leading 0s.
+The '((%Nload%))' argument takes an upgrade index as a number, or an array of numbers with no leading 0s.
 
 #### reorder
 
-The 'reorder' argument takes reorder pairs as objects, or arrays.
+The '((%Nreorder%))' argument takes reorder pairs as objects, or arrays.
 
 ```
 sys.manage { reorder: { from: 0, to: 1 } }

--- a/docs/scripting/trust_scripts/sys.specs.mdx
+++ b/docs/scripting/trust_scripts/sys.specs.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.specs
+description: "Returns the user's system specs"
 ---
 
-sys.specs returns the user's current specifications.
+((sys.specs)) returns the user's current system specifications.
 
 ## Syntax
 
@@ -43,7 +44,7 @@ architect(<score>) scavenger(<score>) executive(<score>) infiltrator(<score>) ju
 
 channel_count: <number of channels user can be in>
 
-gc_max: 9Q7T199B254M740K991GC
+gc_max: (max amount of GC this system tier can hold)
 
 upgrade space
 slots: <current upgrades held>/<max upgrade space>

--- a/docs/scripting/trust_scripts/sys.specs.mdx
+++ b/docs/scripting/trust_scripts/sys.specs.mdx
@@ -44,7 +44,7 @@ architect(<score>) scavenger(<score>) executive(<score>) infiltrator(<score>) ju
 
 channel_count: <number of channels user can be in>
 
-gc_max: (max amount of GC this system tier can hold)
+gc_max: <max amount of GC this system tier can hold>
 
 upgrade space
 slots: <current upgrades held>/<max upgrade space>

--- a/docs/scripting/trust_scripts/sys.status.mdx
+++ b/docs/scripting/trust_scripts/sys.status.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.status
+description: "Returns the user's system status"
 ---
 
-sys.status returns the status of the user that runs it.
+((sys.status)) returns the status of the user that runs it.
 
 ### Security Level
 
@@ -28,9 +29,9 @@ There are no known parameters.
 
 ### Return
 
-sys.specs returns a string.
-
 ### CLI
+
+Returns a string.
 
 ```
 >>sys.status

--- a/docs/scripting/trust_scripts/sys.upgrade_log.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrade_log.mdx
@@ -27,7 +27,7 @@ sys.upgrade_log()
 
 #### user
 
-The '((%Nuser' argument filters sent and recieved upgrades by user.
+The '((%Nuser))' argument filters sent and recieved upgrades by user.
 
 #### run_id
 

--- a/docs/scripting/trust_scripts/sys.upgrade_log.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrade_log.mdx
@@ -27,7 +27,7 @@ sys.upgrade_log()
 
 #### user
 
-The '((%Nuser))' argument filters sent and recieved upgrades by user.
+The '((%Nuser%))' argument filters sent and recieved upgrades by user.
 
 #### run_id
 

--- a/docs/scripting/trust_scripts/sys.upgrade_log.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrade_log.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.upgrade_log
+description: "Displays the user's upgrade log"
 ---
 
-sys.upgrade_log displays information about upgrades which have been sent and recieved.
+((sys.upgrade_log)) displays information about upgrades which have been sent and recieved.
 
 ### Security Level
 
@@ -26,17 +27,19 @@ sys.upgrade_log()
 
 #### user
 
-The 'user' argument filters sent and recieved upgrades by user.
+The '((%Nuser' argument filters sent and recieved upgrades by user.
 
 #### run_id
 
+The '((%Nrun_id%))' argument filters send/receive actions by specific [[run_id:run ID]]s
+
 #### count
 
-The 'count' argument specifies the number of upgrade logs to be displayed.
+The '((%Ncount%))' argument specifies the number of upgrade logs to be displayed.
 
 #### start
 
-The 'start' offsets the start of the upgrade log list to be displayed.
+The '((%Nstart%))' argument offsets the start of the upgrade log list to be displayed.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.upgrades.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrades.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.upgrades
+description: "Displays the user's system upgrades"
 ---
 
-sys.upgrades displays information about the upgrades present on the system.
+((sys.upgrades)) displays information about the upgrades present on the system.
 
 ### Security Level
 
@@ -26,23 +27,15 @@ sys.upgrades
 
 #### filter
 
-The 'filter' parameter takes an object which can specify the properties 'loaded' and 'chars'.
-
-- loaded
-
-Takes a boolean, specifies whether to display loaded upgrades with true, or unloaded upgrades with false.
-
-- chars
-
-Takes MongoDB query compatibles, e.g. `chars: { "$gte" : 2000 }`
+The '((%Nfilter%))' parameter takes an object which can specify properties of the upgrade(s). Can take discrete values or MongoDB compatible queries, e.g. `chars: { "$gte" : 2000 }`
 
 #### full
 
-The 'full' parameter takes a boolean. If the value is set to `true` sys.upgrades will display the full details object of each upgrade.
+The '((%Nfull%))' parameter takes a boolean. If the value is set to ((%Vtrue%)), ((sys.upgrades)) will display the full details object of each upgrade.
 
 #### i
 
-The 'i' parameter takes either a number or an array of numbers.
+The '((%Ni%))' parameter takes either a number or an array of numbers.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.upgrades_of_owner.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrades_of_owner.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.upgrades_of_owner
+description: "Displays the script owner's upgrades"
 ---
 
-> When called as a subscript in a script that is hosted by one user, it allows the upgrades of the script owner to be seen by a different user running the script.
+When called as a subscript in a script that is hosted by one user, ((sys.upgrades_of_owner)) allows the upgrades of the script owner to be seen by a different user running the script.
 
 ### Security Level
 
@@ -26,15 +27,15 @@ sys.upgrades_of_owner
 
 #### filter
 
-The 'filter' argument takes the same filter syntax as [[sys.upgrades]].
+The '((%Nfilter%))' argument takes the same filter syntax as [[sys.upgrades:((sys.upgrades))]].
 
 #### full
 
-The 'full' argument takes a boolean. When the value is set to `true`, sys.upgrades_of_owner will display the full detail arguments of the owner's upgrades.
+The '((%Nfull%))' argument takes a boolean. When the value is set to ((%Vtrue%)), ((sys.upgrades_of_owner)) will display the full detail arguments of the owner's upgrades.
 
 #### i
 
-The 'i' argument takes a number, or an array of numbers, and specifies the index(es) to be displayed.
+The '((%Ni%))' argument takes a number, or an array of numbers, and specifies the index(es) to be displayed.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/sys.xfer_upgrade_to.mdx
+++ b/docs/scripting/trust_scripts/sys.xfer_upgrade_to.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.xfer_upgrade_to
+description: "Sends upgrade(s) to a specified user"
 ---
 
-Sends upgrade(s) to a specified user.
+((sys.xfer_upgrade_to)) sends upgrade(s) to a specified user.
 
 ### Security Level
 
@@ -32,17 +33,28 @@ sys.xfer_upgrade_to { to: "user", i: [ 0, 1, 2 ] }
 
 ### Parameters
 
+Requires '((%Nto%))' and one of '((%Ni%))' or '((%Nsn%))'.
+
 #### to (required)
 
-The 'to' argument takes a username as a string and specifies the username where upgrades shall be sent.
+The '((%Nto%))' argument takes a username as a string and specifies the username where upgrades shall be sent.
 
-#### i (required)
+#### i
 
-The 'i' argument takes a number or array of numbers and specifies the upgrade index(es) to be sent.
+The '((%Ni%))' argument takes a number or array of numbers and specifies which upgrade indexes shall be sent.
+
+#### sn
+
+The '((%Nsn%))' argument takes a serial number string, or array of serial numbers, to specify which serial numbers shall be sent (if they exist on the user).
+
+#### memo (optional)
+
+The '((%Nmemo%))' argument allows for an optional memo, up to 50 characters, alongside the upgrade transfer
+
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/sys.xfer_upgrade_to.mdx
+++ b/docs/scripting/trust_scripts/sys.xfer_upgrade_to.mdx
@@ -51,7 +51,6 @@ The '((%Nsn%))' argument takes a serial number string, or array of serial number
 
 The '((%Nmemo%))' argument allows for an optional memo, up to 50 characters, alongside the upgrade transfer
 
-
 ### Return
 
 Returns a ((%LSuccess%)) or ((%DFailure%)) object.

--- a/docs/scripting/trust_scripts/sys.xfer_upgrade_to_caller.mdx
+++ b/docs/scripting/trust_scripts/sys.xfer_upgrade_to_caller.mdx
@@ -1,8 +1,9 @@
 ---
 title: sys.xfer_upgrade_to_caller
+description: "Sends upgrades from the script owner to the caller"
 ---
 
-accts.xfer_upgrade_to_caller allows a script to send upgrades to the caller of the script.
+((accts.xfer_upgrade_to_caller)) allows a script to send upgrades to the caller of the script.
 
 ### Security Level
 
@@ -32,13 +33,23 @@ Multiple upgrades:
 
 ### Parameters
 
-#### i (required)
+Requires one of '((%Ni%))' or '((%Nsn%))'.
 
-The 'i' argument takes a number or array of numbers and specifies which upgrades shall be sent.
+#### i
+
+The '((%Ni%))' argument takes a number or array of numbers and specifies which upgrade indexes shall be sent.
+
+#### sn
+
+The '((%Nsn%))' argument takes a serial number string, or array of serial numbers, to specify which serial numbers shall be sent (if they exist on the user).
+
+#### memo (optional)
+
+The '((%Nmemo%))' argument allows for an optional memo, up to 50 characters, alongside the upgrade transfer
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/trust.me.mdx
+++ b/docs/scripting/trust_scripts/trust.me.mdx
@@ -1,5 +1,6 @@
 ---
 title: trust.me
+description: ""
 ---
 
 ### Security Level

--- a/docs/scripting/trust_scripts/users.active.mdx
+++ b/docs/scripting/trust_scripts/users.active.mdx
@@ -1,8 +1,9 @@
 ---
 title: users.active
+description: "Displays the number of currently active users"
 ---
 
-Displays the number of currently active users.
+((users.active)) displays the number of currently active users.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/users.config.mdx
+++ b/docs/scripting/trust_scripts/users.config.mdx
@@ -1,8 +1,9 @@
 ---
 title: users.config
+description: "Customizes a user's users.inspect profile"
 ---
 
-users.config provides user profile customization.
+((users.config)) provides user profile customization, for display in [[users.inspect:((users.inspect))]].
 
 ### Security Level
 
@@ -26,43 +27,43 @@ users.config { list: true }
 
 #### list
 
-The 'list' argument displays the possible parameters and syntax.
+The '((%Nlist%))' argument displays the possible parameters and syntax.
 
 #### avatar
 
-The 'avatar' argument takes a string from a list of possible avatars.
+The '((%Navatar%))' argument takes a string from a list of possible avatars.
 
 #### user_age
 
-The 'user_age' takes a boolean and toggles displaying user age in the YYMMDD.HHMM format.
+The '((%Nuser_age%))' takes a boolean and toggles displaying user age in the YYMMDD.HHMM format.
 
 #### account_age
 
-The 'account_age' argument takes a boolean and toggles displaying account age in the YYMMDD.HHMM format.
+The '((%Naccount_age%))' argument takes a boolean and toggles displaying account age in the YYMMDD.HHMM format.
 
 #### bio
 
-The 'bio' argument takes a string.
+The '((%Nbio%))' argument takes a string.
 
 #### title
 
-The 'title' argument takes a string from a list of possible titles.
+The '((%Ntitle%))' argument takes a string from a list of possible titles.
 
 #### pronouns
 
-The 'pronouns' argument takes a string.
+The '((%Npronouns%))' argument takes a string.
 
 #### corp
 
-The 'corp' argument takes a boolean and toggles displaying corp membership.
+The '((%Ncorp%))' argument takes a boolean and toggles displaying corp membership.
 
 #### is_main
 
-The 'is_main' argument takes a boolean and toggles displaying that this user is a main user.
+The '((%Nis_main%))' argument takes a boolean and toggles displaying that this user is a main user.
 
 #### alt_of
 
-The 'alt_of' argument takes a boolean and toggles displaying name of main user this is an alt of.
+The '((%Nalt_of%))' argument takes a boolean and toggles displaying name of main user this is an alt of.
 
 ### Return
 
@@ -79,7 +80,7 @@ Usage: users.inspect { name:<username> }
 Requires connection to user (hardline or channel)
 ```
 
-list: true
+((list: true))
 
 ```
 >>users.config { list: true }

--- a/docs/scripting/trust_scripts/users.config.mdx
+++ b/docs/scripting/trust_scripts/users.config.mdx
@@ -63,7 +63,7 @@ The '((%Nis_main%))' argument takes a boolean and toggles displaying that this u
 
 #### alt_of
 
-The '((%Nalt_of%))' argument takes a boolean and toggles displaying name of main user this is an alt of.
+The '((%Nalt_of%))' argument takes a string specifying which main user this is an alt of. The named user must have ((%Nis_main%)) set to ((%Vtrue%)).
 
 ### Return
 

--- a/docs/scripting/trust_scripts/users.inspect.mdx
+++ b/docs/scripting/trust_scripts/users.inspect.mdx
@@ -1,8 +1,9 @@
 ---
 title: users.inspect
+description: "Displays the specified user's profile"
 ---
 
-users.inspect displays the profile of a specified user.
+((users.inspect)) displays the profile of a specified user.
 
 ### Security Level
 
@@ -26,7 +27,7 @@ users.inspect { name: "seanmakesgames" }
 
 #### name (required)
 
-The 'name' argument takes a string and specifies the user to inspect.
+The '((%Nname%))' argument takes a string and specifies the user to inspect.
 
 #### badge_info (optional)
 

--- a/docs/scripting/trust_scripts/users.last_action.mdx
+++ b/docs/scripting/trust_scripts/users.last_action.mdx
@@ -1,8 +1,9 @@
 ---
 title: users.last_action
+description: "Displays the time of a specified user's last action"
 ---
 
-users.last_action displays a timestamp from a specified user's most recent action.
+((users.last_action)) displays a timestamp from a specified user's most recent action.
 
 ### Security Level
 
@@ -26,7 +27,7 @@ users.last_action { name: "trust" }
 
 #### name (required)
 
-The 'name' argument takes a string and specifies which user's last action shall be checked.
+The '((%Nname%))' argument takes a string and specifies which user's last action shall be checked.
 
 ### Return
 

--- a/docs/scripting/trust_scripts/users.top.mdx
+++ b/docs/scripting/trust_scripts/users.top.mdx
@@ -1,8 +1,9 @@
 ---
 title: users.top
+description: "Displays the top 10 users by GC"
 ---
 
-Displays top 10 users by GC.
+((users.top)) displays the domain's top 10 users by ((%CGC%)).
 
 ### Security Level
 


### PR DESCRIPTION
### Problem

The trust script pages were written before the autocolor plugin went live, so the pages could do with a lot of clarifying colors.

### Context

The scope of this PR crept a little bit, but the main things it tackles are:

- Coloring the trust script names, args, GC values, user names etc.
- Fixing a few typos/incorrect bits of info
- Adding links to pages that now exist (primarily run IDs)
- Adding `description` frontmatter to each page to prevent color-plugin-parenths from showing up