### PR TITLE
added stats to sn_w_glock

### DIFF
--- a/docs/upgrades/locks/sn_w_glock.mdx
+++ b/docs/upgrades/locks/sn_w_glock.mdx
@@ -8,7 +8,9 @@ sn_w_glock is a tier 2 lock created by the sn_w inc corporation.
 
 ## Stats
 
-Unique stats that are included in the lock's statistics. The lock spawns at rarities ((%1kiddie%)), ((%2h4x0r%)), and ((%3h4rdc0r3%)).
+sn_w_glock includes 2 additional stats. 'max_glock_amnt' which defines the maximum amount of GC the upgrade can take,
+and 'expire_secs' which shows the amount of time after being solved that the lock will stay open before re-activating.
+The lock spawns at rarities ((%1kiddie%)), ((%2h4x0r%)), and ((%3h4rdc0r3%)).
 
 ## Behavior
 


### PR DESCRIPTION
Details of the stats for sn_w_glock were missing.

Added the info under the stats heading.
