### PR TITLE
corrected mulberry32.mdx syntax example

### DIFF
--- a/docs/scripting/scripts.lib/mulberry32.mdx
+++ b/docs/scripting/scripts.lib/mulberry32.mdx
@@ -7,7 +7,7 @@ A function that gets a random number from a numerical seed based on the mulberry
 ## Syntax
 
 ```js
-#fs.scripts.lib().mulbery32(num);
+#fs.scripts.lib().mulberry32(num);
 ```
 
 ### Parameters


### PR DESCRIPTION
Fixed typo in the syntax example (mulbery32())
