### PR TITLE
Rewrite `escrow.charge` page a little

### DIFF
--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -56,6 +56,13 @@ Failure
 Running this script costs 1GC each use. Confirm with escrow.confirm { i:"token5" }
 ```
 
+:::warning
+If escrow.charge is called more than once within a single script run, it will return
+```
+{ ok: "false", msg: "escrow.charge has already been called in this script run." }
+```
+after the first run.
+
 ## Example
 
 ```js

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -62,6 +62,7 @@ If escrow.charge is called more than once within a single script run, it will re
 { ok: "false", msg: "escrow.charge has already been called in this script run." }
 ```
 after the first run.
+:::
 
 ## Example
 

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -57,7 +57,7 @@ Running this script costs 1GC each use. Confirm with escrow.confirm { i:"token5"
 ```
 
 :::warning
-If escrow.charge is called more than once within a single script run, it will return
+If escrow.charge is called more than once within a single script run (from any script), it will return
 
 ```
 { ok: "false", msg: "escrow.charge has already been called in this script run." }

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -35,7 +35,7 @@ The '((%Nis_unlim%))' argument specifies whether the escrow cost is per-run, or 
 
 ### Return
 
-Returns an object.
+Returns an object; or `null` if access should be granted.
 
 #### CLI
 

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -27,7 +27,7 @@ escrow.charge { cost: "1GC", is_unlim: true }
 
 #### cost (required)
 
-The '((%Ncost%))' argument specifies a script-runs' escrow cost.
+The '((%Ncost%))' argument specifies a script-run's escrow cost.
 
 #### is_unlim (required)
 

--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -58,9 +58,11 @@ Running this script costs 1GC each use. Confirm with escrow.confirm { i:"token5"
 
 :::warning
 If escrow.charge is called more than once within a single script run, it will return
+
 ```
 { ok: "false", msg: "escrow.charge has already been called in this script run." }
 ```
+
 after the first run.
 :::
 


### PR DESCRIPTION
### Problem

The `escrow.charge` page was missing some, imo, critical information.


### TODOs

Once these are completed, this PR can be undrafted:
- [x] Check whether the once-per-run lockout is per-calling-script or not; and add that information to the page.