### PR TITLE
Add missing h4rdc0r3 rarity spawn to k3y_v2 page

### DIFF
--- a/docs/upgrades/infiltrator/key_v2.mdx
+++ b/docs/upgrades/infiltrator/key_v2.mdx
@@ -4,7 +4,7 @@ title: k3y_v2
 
 > Keep your nuutec l0cket safe with a security k3y
 
-k3y_v2 is a tier 2 upgrade. It spawns at ((%0noob%)), ((%1kiddie%)) and ((%2h4x0r%)) rarities.
+k3y_v2 is a tier 2 upgrade. It spawns at ((%0noob%)), ((%1kiddie%)), ((%2h4x0r%)) and ((%3h4rdc0r3%))rarities.
 
 ## Stats
 


### PR DESCRIPTION
### Problem
The k3y_v2 page indicated that it could only spawn in rarities 0-2 when it can also spawn as rarity 3.