### PR TITLE
Correct color code 0 to 9B9B9B

### DIFF
--- a/docs/scripting/syntax/colors.mdx
+++ b/docs/scripting/syntax/colors.mdx
@@ -19,7 +19,7 @@ An example:
 
 | Alphanumeric identifier | RGB color value |
 | ----------------------- | --------------- |
-| 0                       | ((%0#FFFFFF%))  |
+| 0                       | ((%0#9B9B9B%))  |
 | 1                       | ((%1#FFFFFF%))  |
 | 2                       | ((%2#1EFF00%))  |
 | 3                       | ((%3#0070DD%))  |


### PR DESCRIPTION
### Problem

Color code `0`  is `FFFFFF`, which is wrong (should be `9B9B9B`)