### PR TITLE
rm redundancy from script_call

### DIFF
--- a/docs/scripting/directives/script_call.mdx
+++ b/docs/scripting/directives/script_call.mdx
@@ -12,7 +12,7 @@ Call a script from within another script.
 #Xs.user.script(args)
 ```
 
-Where `Xs` is the security level of the script you wish to call the subscript at.
+Where `Xs` is the security level you wish to call the subscript at.
 
 | Letter | Number | Security Level |
 | ------ | ------ | -------------- |


### PR DESCRIPTION
### Problem

Redundantly-written sentence in the subscript call page