### PR TITLE
Link to locks page from locks

### DIFF
--- a/docs/upgrades/locks/CON_SPEC.mdx
+++ b/docs/upgrades/locks/CON_SPEC.mdx
@@ -4,7 +4,7 @@ title: CON_SPEC
 
 > Two roads diverged. I took the less traveled.
 
-CON_SPEC is a tier 2 [[lock]] created by the context corporation.
+CON_SPEC is a tier 2 [lock](/upgrades/locks) created by the context corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/CON_TELL.mdx
+++ b/docs/upgrades/locks/CON_TELL.mdx
@@ -4,7 +4,7 @@ title: CON_TELL
 
 > CON_TELL attempts to send a tell to the owner of the lock
 
-CON_TELL is a tier 1 [[lock]] created by the CONTEXT corporation.
+CON_TELL is a tier 1 [lock](/upgrades/locks) created by the CONTEXT corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/DATA_CHECK_V1.mdx
+++ b/docs/upgrades/locks/DATA_CHECK_V1.mdx
@@ -4,7 +4,7 @@ title: DATA_CHECK_V1
 
 > it is valuable to verify the common elements of trust's truth, and other truths besides
 
-DATA_CHECK_V1 is a tier 1 [[lock]].
+DATA_CHECK_V1 is a tier 1 [lock](/upgrades/locks).
 
 ## Stats
 

--- a/docs/upgrades/locks/DATA_CHECK_V2.mdx
+++ b/docs/upgrades/locks/DATA_CHECK_V2.mdx
@@ -4,7 +4,7 @@ title: DATA_CHECK_V2
 
 > it is valuable to verify the common elements of trust's truth, and other truths besides
 
-DATA_CHECK_V2 is a tier 2 [[lock]].
+DATA_CHECK_V2 is a tier 2 [lock](/upgrades/locks).
 
 ## Stats
 

--- a/docs/upgrades/locks/c001.mdx
+++ b/docs/upgrades/locks/c001.mdx
@@ -4,7 +4,7 @@ title: c001
 
 > The CORE 'c' line of locks provides entry level protection for the concerned consumer. The 001 is the first of that line.
 
-c001 is a tier 1 [[lock]] created by the CORE corporation.
+c001 is a tier 1 [lock](/upgrades/locks) created by the CORE corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/c002.mdx
+++ b/docs/upgrades/locks/c002.mdx
@@ -4,7 +4,7 @@ title: c002
 
 > The CORE c002 adds slight protection over the 001. Still mediocre.
 
-c002 is a tier 1 [[lock]] created by the CORE corporation.
+c002 is a tier 1 [lock](/upgrades/locks) created by the CORE corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/c003.mdx
+++ b/docs/upgrades/locks/c003.mdx
@@ -4,7 +4,7 @@ title: c003
 
 > c003 from CORE. Additional complexity, additional cost.
 
-c003 is a tier 1 [[lock]] created by the CORE corporation.
+c003 is a tier 1 [lock](/upgrades/locks) created by the CORE corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/ez_21.mdx
+++ b/docs/upgrades/locks/ez_21.mdx
@@ -4,7 +4,7 @@ title: ez_21
 
 > From the Halperyon Systems' EZ line comes the 21. A very unexceptional lock, unless you count the price: dirt-cheap.
 
-ez_21 is a tier 1 [[lock]] created by the HALPERYON SYSTEMS corporation.
+ez_21 is a tier 1 [lock](/upgrades/locks) created by the HALPERYON SYSTEMS corporation.
 
 ### Stats
 

--- a/docs/upgrades/locks/ez_35.mdx
+++ b/docs/upgrades/locks/ez_35.mdx
@@ -4,7 +4,7 @@ title: ez_35
 
 > Halperyon Systems' EZ 35. A step up from the 21, but not much.
 
-ez_35 is a tier 1 [[lock]] created by the HALPERYON SYSTEMS corporation.
+ez_35 is a tier 1 [lock](/upgrades/locks) created by the HALPERYON SYSTEMS corporation.
 
 ### Stats
 
@@ -46,7 +46,7 @@ Connection terminated.
 <details>
   <summary>Spoilers for ez_35's solutions.</summary>
   The first parameter's possible strings are, "open", "unlock", and "release".
-  
+
 ```
 >>user.loc { }
 LOCK_ERROR

--- a/docs/upgrades/locks/ez_40.mdx
+++ b/docs/upgrades/locks/ez_40.mdx
@@ -4,7 +4,7 @@ title: ez_40
 
 > Halperyon Systems' EZ 40. Wait, I can't remember if 1 is prime or not.
 
-ez_40 is a tier 1 [[lock]] created by the HALPERYON SYSTEMS corporation.
+ez_40 is a tier 1 [lock](/upgrades/locks) created by the HALPERYON SYSTEMS corporation.
 
 ### Stats
 

--- a/docs/upgrades/locks/l0ckbox.mdx
+++ b/docs/upgrades/locks/l0ckbox.mdx
@@ -4,7 +4,7 @@ title: l0ckbox
 
 > The nuutec l0ckbox secures you and your cuddlyone from prying eyes
 
-l0ckbox is a tier 2 [[lock]] created by the NUUTEC corporation.
+l0ckbox is a tier 2 [lock](/upgrades/locks) created by the NUUTEC corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/l0cket.mdx
+++ b/docs/upgrades/locks/l0cket.mdx
@@ -4,7 +4,7 @@ title: l0cket
 
 > The nuutec security systems l0cket provides entry level security for you and your best pal
 
-l0cket is a tier 1 [[lock]] created by the NUUTEC SECURITY SYSTEMS corporation.
+l0cket is a tier 1 [lock](/upgrades/locks) created by the NUUTEC SECURITY SYSTEMS corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/magnara.mdx
+++ b/docs/upgrades/locks/magnara.mdx
@@ -4,7 +4,7 @@ title: magnara
 
 > mi ton sreu ohw tish skowr
 
-magnara is a tier 2 [[lock]] created by the #FUTUREtech corporation.
+magnara is a tier 2 [lock](/upgrades/locks) created by the #FUTUREtech corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/w4rn.mdx
+++ b/docs/upgrades/locks/w4rn.mdx
@@ -4,7 +4,7 @@ title: w4rn
 
 > Archaic Labs' warning lock. Displays a message to connected users. Message can be changed with w4rn_message.
 
-w4rn is a tier 1 [[lock]] created by the ARCHAIC LABS corporation.
+w4rn is a tier 1 [lock](/upgrades/locks) created by the ARCHAIC LABS corporation.
 
 ## Stats
 

--- a/docs/upgrades/locks/w4rn_er.mdx
+++ b/docs/upgrades/locks/w4rn_er.mdx
@@ -4,7 +4,7 @@ title: w4rn_er
 
 > ???
 
-w4rn is a tier 1 [[lock]].
+w4rn is a tier 1 [lock](/upgrades/locks).
 
 ### Stats
 


### PR DESCRIPTION
### Problem

The lock links went nowhere, now they go to https://wiki.hackmud.com/upgrades/locks