### PR TITLE
Fix `escrow.charge` example

### DIFF
--- a/docs/scripting/trust_scripts/escrow.charge.mdx
+++ b/docs/scripting/trust_scripts/escrow.charge.mdx
@@ -71,12 +71,12 @@ after the first run.
 ```js
 function(context, args)
 {
-	var smiley_face = ":)"
+	var smiley_face = ":)";
 	var result = #fs.escrow.charge({ cost: 1, is_unlim: false });
 	if( result ) {
-		return smiley_face
+		return result;
 	} else {
-		return result
+		return smiley_face;
 	}
 }
 ```


### PR DESCRIPTION
### Problem
The example escrow script had the conditions backwards. If `escrow.charge` returns an object, you want to forward it to the player. If it is `null`, the charge is paid.

Added semis for consistency with the line that had one.
