### PR TITLE
Fix incorrect 'deletion' mentions on the DB wiki pages

### DIFF
--- a/docs/scripting/db/db.u.mdx
+++ b/docs/scripting/db/db.u.mdx
@@ -30,12 +30,12 @@ Update operators can be used to set new individual values, increment integer val
 
 An object is returned upon updating documents with this function, providing extra details about whether it succeeded:
 
-| Key       | Information                                                                      |
-| --------- | -------------------------------------------------------------------------------- |
-| n         | Number of documents matched in the query                                         |
-| nModified | Number of documents modified, after evaluating all update expressions            |
-| ok        | If the operation succeeded, == 1                                                 |
-| opTime    | Object that contains a property 't' -- time of update operation in millieconds   |
+| Key       | Information                                                                    |
+| --------- | ------------------------------------------------------------------------------ |
+| n         | Number of documents matched in the query                                       |
+| nModified | Number of documents modified, after evaluating all update expressions          |
+| ok        | If the operation succeeded, == 1                                               |
+| opTime    | Object that contains a property 't' -- time of update operation in millieconds |
 
 ## Example
 

--- a/docs/scripting/db/db.u.mdx
+++ b/docs/scripting/db/db.u.mdx
@@ -35,7 +35,7 @@ An object is returned upon updating documents with this function, providing extr
 | n         | Number of documents matched in the query                                         |
 | nModified | Number of documents modified, after evaluating all update expressions            |
 | ok        | If the operation succeeded, == 1                                                 |
-| opTime    | Object that contains a property 't' -- time of deletion operation in millieconds |
+| opTime    | Object that contains a property 't' -- time of update operation in millieconds   |
 
 ## Example
 

--- a/docs/scripting/db/db.u1.mdx
+++ b/docs/scripting/db/db.u1.mdx
@@ -35,7 +35,7 @@ An object is returned upon updating documents with this function, providing extr
 | n         | Number of documents matched in the query. This will only ever be 0 or 1                              |
 | nModified | Number of documents modified, after evaluating all update expressions. This will only ever be 0 or 1 |
 | ok        | If the operation succeeded, == 1                                                                     |
-| opTime    | Object that contains a property 't' -- time of deletion operation in millieconds                     |
+| opTime    | Object that contains a property 't' -- time of update operation in millieconds                       |
 
 ## Example
 

--- a/docs/scripting/db/db.us.mdx
+++ b/docs/scripting/db/db.us.mdx
@@ -40,7 +40,7 @@ An object is returned upon updating documents with this function, providing extr
 | nModified | Number of documents modified, after evaluating all update expressions            |
 | upserted  | If an upsertion occurred, provides an index integer                              |
 | ok        | If the operation succeeded, == 1                                                 |
-| opTime    | Object that contains a property 't' -- time of deletion operation in millieconds |
+| opTime    | Object that contains a property 't' -- time of operation in millieconds          |
 
 ## Example
 

--- a/docs/scripting/db/db.us.mdx
+++ b/docs/scripting/db/db.us.mdx
@@ -34,13 +34,13 @@ The conditions of the update will be applied to the new document alongside its i
 
 An object is returned upon updating documents with this function, providing extra details about whether it succeeded:
 
-| Key       | Information                                                                      |
-| --------- | -------------------------------------------------------------------------------- |
-| n         | Number of documents matched in the query                                         |
-| nModified | Number of documents modified, after evaluating all update expressions            |
-| upserted  | If an upsertion occurred, provides an index integer                              |
-| ok        | If the operation succeeded, == 1                                                 |
-| opTime    | Object that contains a property 't' -- time of operation in millieconds          |
+| Key       | Information                                                             |
+| --------- | ----------------------------------------------------------------------- |
+| n         | Number of documents matched in the query                                |
+| nModified | Number of documents modified, after evaluating all update expressions   |
+| upserted  | If an upsertion occurred, provides an index integer                     |
+| ok        | If the operation succeeded, == 1                                        |
+| opTime    | Object that contains a property 't' -- time of operation in millieconds |
 
 ## Example
 


### PR DESCRIPTION
### Problem

The db return object explanations were copy-pasted from #db.r and need to be updates
