### PR TITLE
Document 'is_script' argument for sys.upgrades

### DIFF
--- a/docs/scripting/trust_scripts/sys.upgrades.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrades.mdx
@@ -37,6 +37,12 @@ The '((%Nfull%))' parameter takes a boolean. If the value is set to ((%Vtrue%)),
 
 The '((%Ni%))' parameter takes either a number or an array of numbers.
 
+#### is_script
+
+The '((%Nis_script%))' parameter takes a boolean. If the value is set to ((%Vtrue%)), ((sys.upgrades)) returns the same output as if the script was called inside of a script.
+
+If it is false, it returns the same output as if the script was called from the CLI.
+
 ### Return
 
 Returns an object.

--- a/docs/scripting/trust_scripts/sys.upgrades.mdx
+++ b/docs/scripting/trust_scripts/sys.upgrades.mdx
@@ -41,7 +41,7 @@ The '((%Ni%))' parameter takes either a number or an array of numbers.
 
 The '((%Nis_script%))' parameter takes a boolean. If the value is set to ((%Vtrue%)), ((sys.upgrades)) returns the same output as if the script was called inside of a script.
 
-If it is false, it returns the same output as if the script was called from the CLI.
+If it is ((%Vfalse%)), it returns the same output as if the script was called from the CLI.
 
 ### Return
 


### PR DESCRIPTION
### Problem

The `is_script` argument for `sys.upgrades` was undocumented
