### PR TITLE
Add missing sn_w_glock solution

### DIFF
--- a/docs/upgrades/locks/sn_w_glock.mdx
+++ b/docs/upgrades/locks/sn_w_glock.mdx
@@ -62,6 +62,8 @@ Based on a certain word that is inside of the sn_w_glock's return value.
   GC:"1K89GC"
 - WORD:"elite"<br />
   GC:"1K337GC"
+- WORD:"monolithic"<br />
+  GC:"2K1GC"
 
 These words can be anywhere in the string that sn_w_glock gives you.
 


### PR DESCRIPTION
### Problem

The documentation for `sn_w_glock` was missing the solution of 2K1GC when prompted with `Not a monolithic balance.`