### PR TITLE
Correct sys.init article

### DIFF
--- a/docs/scripting/trust_scripts/sys.init.mdx
+++ b/docs/scripting/trust_scripts/sys.init.mdx
@@ -3,7 +3,7 @@ title: sys.init
 description: "Initializes a system, or upgrades its tier"
 ---
 
-((sys.init)) initializes a system, or upgrades its tier once it is initialized.
+((sys.init)) initializes a system, or upgrades its tier once it is initialized. ((sys.init)) also lists what features will be available at the next tier.
 
 ### Security Level
 
@@ -23,13 +23,13 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-#### confirm (required)
+#### confirm
 
 The '((%Nconfirm%))' parameter confirms system initialization.
 
 ### Return
 
-Returns a ((%LSuccess%)) or ((%DFaliure%)) object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object, or a string.
 
 #### CLI
 
@@ -49,6 +49,22 @@ Correct parameters:
 Success
 
 Transferred 1MGC to trust
+```
+
+If balance is too low to initialize:
+
+```
+>>sys.init
+Failure
+Your account balance of 580K141GC is too low to send 10MGC.
+```
+
+If system is already at maximum tier:
+
+```
+>>sys.init
+Failure
+Your system is fully initialized.
 ```
 
 #### Script

--- a/docs/scripting/trust_scripts/sys.init.mdx
+++ b/docs/scripting/trust_scripts/sys.init.mdx
@@ -51,7 +51,7 @@ Success
 Transferred 1MGC to trust
 ```
 
-If balance is too low to initialize:
+If balance is too low to initialize or upgrade:
 
 ```
 >>sys.init


### PR DESCRIPTION
Adds additional information, corrects a typo, and corrects the return type.

### Problem

Fixes #443 
