### PR TITLE
Fix typo in How to Report Issues

### DIFF
--- a/docs/guides/misc/report_issues.mdx
+++ b/docs/guides/misc/report_issues.mdx
@@ -2,7 +2,7 @@
 title: How to Report Issues
 ---
 
-_hackmud_ is an incredibly complex system and simulation. Often times it's hard to reason about and tell the difference between what is intended and what is not intended in interactions with the game. This lack of understanding and grayness can be extremely fun and rewarding. It can also be incredibly frustrating. This article clarifies different categories of issues, how to report them, and what to expect in the response.
+_hackmud_ is an incredibly complex system and simulation. Oftentimes it's hard to reason about and tell the difference between what is intended and what is not intended in interactions with the game. This lack of understanding and grayness can be extremely fun and rewarding. It can also be incredibly frustrating. This article clarifies different categories of issues, how to report them, and what to expect in the response.
 
 ## Sandbox Breaks
 


### PR DESCRIPTION
"Oftentimes" is actually one word, my bad
