### PR TITLE
Rewrite non-function scripts.lib property pages to remove function language

### DIFF
--- a/docs/scripting/scripts.lib/colors.mdx
+++ b/docs/scripting/scripts.lib/colors.mdx
@@ -12,7 +12,8 @@ A string containing the lowercase alphabet, followed by the uppercase alphabet. 
 
 ### Value
 
-This property is a string.
+This property is the literal string:  
+`"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"`
 
 ## Example
 

--- a/docs/scripting/scripts.lib/colors.mdx
+++ b/docs/scripting/scripts.lib/colors.mdx
@@ -2,7 +2,7 @@
 title: .colors
 ---
 
-Used by itself, this will return the lowercase alphabet, followed by the uppercase alphabet. This is a helper function for coloring strings. It may also be used in combination with corruption character functionality in scripts.lib.
+A string containing the lowercase alphabet, followed by the uppercase alphabet. This is a helper property for coloring strings. It is also used for corruption character functionality in scripts.lib.
 
 ## Syntax
 
@@ -10,13 +10,9 @@ Used by itself, this will return the lowercase alphabet, followed by the upperca
 #fs.scripts.lib().colors;
 ```
 
-### Parameters
+### Value
 
-No known parameters.
-
-### Return
-
-Returns a string.
+This property is a string.
 
 ## Example
 

--- a/docs/scripting/scripts.lib/corruption_chars.mdx
+++ b/docs/scripting/scripts.lib/corruption_chars.mdx
@@ -16,7 +16,7 @@ This property is the literal string:
 `"¡¢Á¤Ã¦§¨©ª"`
 
 :::note
-These characters appear different in non-hackmud fonts, but will render as corruption characters when used inside the game: ¡¢Á¤Ã¦§¨©ª.
+These characters appear different in non-hackmud fonts, but will render as corruption characters when used inside the game: "¡¢Á¤Ã¦§¨©ª".
 :::
 
 ## Example

--- a/docs/scripting/scripts.lib/corruption_chars.mdx
+++ b/docs/scripting/scripts.lib/corruption_chars.mdx
@@ -12,7 +12,12 @@ The possible corruption characters.
 
 ### Value
 
-This property is a string.
+This property is the literal string:  
+`"¡¢Á¤Ã¦§¨©ª"`
+
+:::note
+These characters appear different in non-hackmud fonts, but will render as corruption characters when used inside the game: ¡¢Á¤Ã¦§¨©ª.
+:::
 
 ## Example
 

--- a/docs/scripting/scripts.lib/corruption_chars.mdx
+++ b/docs/scripting/scripts.lib/corruption_chars.mdx
@@ -2,7 +2,7 @@
 title: .corruption_chars
 ---
 
-Displays the possible corruption characters.
+The possible corruption characters.
 
 ## Syntax
 
@@ -10,13 +10,9 @@ Displays the possible corruption characters.
 #fs.scripts.lib().corruption_chars;
 ```
 
-### Parameters
+### Value
 
-No known parameters.
-
-### Return
-
-Returns a string.
+This property is a string.
 
 ## Example
 

--- a/docs/scripting/scripts.lib/corruptions.mdx
+++ b/docs/scripting/scripts.lib/corruptions.mdx
@@ -2,7 +2,7 @@
 title: .corruptions
 ---
 
-Displays the common corruption frequencies used in-game.
+The common corruption frequencies used in-game.
 
 ## Syntax
 
@@ -10,13 +10,9 @@ Displays the common corruption frequencies used in-game.
 #fs.scripts.lib().corruptions;
 ```
 
-### Parameters
+### Value
 
-No known parameters.
-
-### Return
-
-Returns an array.
+This property is an array.
 
 ## Example
 

--- a/docs/scripting/scripts.lib/corruptions.mdx
+++ b/docs/scripting/scripts.lib/corruptions.mdx
@@ -12,7 +12,8 @@ The common corruption frequencies used in-game.
 
 ### Value
 
-This property is an array.
+This property is the literal array:  
+`[0, 1, 1.5, 2.5, 5]`
 
 ## Example
 

--- a/docs/scripting/scripts.lib/one_day_ms.mdx
+++ b/docs/scripting/scripts.lib/one_day_ms.mdx
@@ -12,7 +12,7 @@ The number of milliseconds equal to 24 hours.
 
 ### Value
 
-This property is the literal array:  
+This property is the literal number:  
 `86400000`
 
 ## Example

--- a/docs/scripting/scripts.lib/one_day_ms.mdx
+++ b/docs/scripting/scripts.lib/one_day_ms.mdx
@@ -10,13 +10,10 @@ The number of milliseconds equal to 24 hours.
 #fs.scripts.lib().one_day_ms;
 ```
 
-### Parameters
+### Value
 
-No known parameters.
-
-### Return
-
-Returns a number.
+This property is the literal array:  
+`86400000`
 
 ## Example
 

--- a/docs/scripting/scripts.lib/security_level_names.mdx
+++ b/docs/scripting/scripts.lib/security_level_names.mdx
@@ -10,13 +10,9 @@ A predefined list of security level names.
 #fs.scripts.lib().security_level_names;
 ```
 
-### Parameters
-
-No known parameters.
-
 ### Value
 
-Returns an array.
+This property is an array.
 
 `["NULLSEC", "LOWSEC", "MIDSEC", "HIGHSEC", "FULLSEC"]`
 

--- a/docs/scripting/scripts.lib/security_level_names.mdx
+++ b/docs/scripting/scripts.lib/security_level_names.mdx
@@ -12,8 +12,7 @@ A predefined list of security level names.
 
 ### Value
 
-This property is an array.
-
+This property is the literal array:  
 `["NULLSEC", "LOWSEC", "MIDSEC", "HIGHSEC", "FULLSEC"]`
 
 ## Example


### PR DESCRIPTION
### Problem

The `scripts.lib` pages for properties that aren't functions includes language specific to functions ("parameters", "returns"), despite the fact these are... not functions.

### Context

`.security_level_names` seems to have had an initial pass at this, replacing the "Return" section with "Value" -- I've done the same for the other pages, as well as changed `Returns` to `This property is`.
