### PR TITLE
Correct acct_nt spent/earned modes

### DIFF
--- a/docs/upgrades/locks/acct_nt.mdx
+++ b/docs/upgrades/locks/acct_nt.mdx
@@ -84,7 +84,7 @@ Add up all the transactions between the two timestamps, with incoming transactio
 <details>
 <summary>Spoilers for acct_nt's solutions </summary>
 
-Add up all the incoming transactions between the two timestamps. The actual starting and ending timestamps may be incorrect by up to one minute.
+Add up all the transactions between the two timestamps, with incoming transactions being positive and outgoing transactions being negative. The actual starting and ending timestamps may be incorrect by up to one minute.
 
 </details>
 
@@ -93,7 +93,7 @@ Add up all the incoming transactions between the two timestamps. The actual star
 <details>
 <summary>Spoilers for acct_nt's solutions </summary>
 
-Add up all the outgoing transactions between the two timestamps. The actual starting and ending timestamps may be incorrect by up to one minute.
+Add up all the transactions between the two timestamps, with outgoing transactions being positive and incoming transactions being negative. The actual starting and ending timestamps may be incorrect by up to one minute.
 
 </details>
 


### PR DESCRIPTION
The spent/earned modes  take into account all transactions, not just outgoing/incoming ones respectively
