### PR TITLE
Update gui.quiet page

### DIFF
--- a/docs/scripting/trust_scripts/gui.quiet.mdx
+++ b/docs/scripting/trust_scripts/gui.quiet.mdx
@@ -3,7 +3,7 @@ title: gui.quiet
 description: "Quietens a user's chats in the terminal"
 ---
 
-((gui.quiet)) prevents a user's chats from appearing in the terminal.
+((gui.quiet)) hides a user's chats in the terminal by darkening the text.
 
 ### Security Level
 

--- a/docs/scripting/trust_scripts/gui.quiet.mdx
+++ b/docs/scripting/trust_scripts/gui.quiet.mdx
@@ -43,7 +43,7 @@ The '((%Nclear%))' argument takes a boolean (true/false). If the value is set to
 
 ### Return
 
-Returns a Success or Failure object.
+Returns a ((%LSuccess%)) or ((%DFailure%)) object.
 
 #### CLI
 


### PR DESCRIPTION
Two changes were made;

1) `gui.quiet` doesn't remove a user's chats, it simply hides them by coloring their name, and their message a darker color. The description was updated to reflect this.
2) There was a `Success` and `Failure` object reference near the bottom of the page that was missing the green and red coloring they normally come with.