### PR TITLE
ci: upgrade github action dependencies for required node and pnpm versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   NODE_INSTALL_VERSION: 20.x
-  PNPM_INSTALL_VERSION: 8
+  PNPM_INSTALL_VERSION: 9
   ALGOLIA_APPID: ${{ vars.ALGOLIA_APPID }}
   ALGOLIA_SEARCH_API_KEY: ${{ vars.ALGOLIA_SEARCH_API_KEY }}
 
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_INSTALL_VERSION }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_INSTALL_VERSION }}
           cache: pnpm
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_INSTALL_VERSION }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_INSTALL_VERSION }}
           cache: pnpm

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   NODE_INSTALL_VERSION: 20.x
-  PNPM_INSTALL_VERSION: 8
+  PNPM_INSTALL_VERSION: 9
   ALGOLIA_APPID: ${{ vars.ALGOLIA_APPID }}
   ALGOLIA_SEARCH_API_KEY: ${{ vars.ALGOLIA_SEARCH_API_KEY }}
 
@@ -32,11 +32,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_INSTALL_VERSION }}
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_INSTALL_VERSION }}
           cache: pnpm


### PR DESCRIPTION
### Problem

Our build scripts depend on [pnpm/action-setup](https://github.com/pnpm/action-setup) and [actions/setup-node](https://github.com/actions/setup-node), which rely on Node 16 according to build artifact logs:

    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2, actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

As Node 16 is now EOL in GitHub Actions ([since Nov 12](https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/)), we should pin the dependencies to the Node 20 as recommended (and correctly reflecting our package.json)

### Context

`pnpm/action-setup@v2` -> `pnpm/action-setup@v4`
`actions/setup-node@v3` -> `actions/setup-node@v4`

I have also bumped the pnpm version to 9, as this is the correct version for the current checked in lock file (resolves #484).

I've initially submitted these changes together in anticipation that these dependencies are tightly coupled / to prevent spurious errors, and because our local development environments have been using pnpm 9 and Node 20 already without issues.