### PR TITLE
Fix Success/Failure object coloring across the wiki

### DIFF
--- a/docs/scripting/scripts.lib/not_impl.mdx
+++ b/docs/scripting/scripts.lib/not_impl.mdx
@@ -2,7 +2,7 @@
 title: .not_impl()
 ---
 
-Returns a Failure object with error message: "Not Implemented".
+Returns a ((%DFailure%)) object with error message: "Not Implemented".
 
 ## Syntax
 

--- a/docs/scripting/scripts.lib/ok.mdx
+++ b/docs/scripting/scripts.lib/ok.mdx
@@ -2,7 +2,7 @@
 title: .ok()
 ---
 
-Helper function that creates a formatted Success object.
+Helper function that creates a formatted ((%LSuccess%)) object.
 
 ## Syntax
 

--- a/docs/scripting/trust_scripts/gui.vfx.mdx
+++ b/docs/scripting/trust_scripts/gui.vfx.mdx
@@ -23,7 +23,7 @@ Cannot be called as a subscript.
 
 ### Parameters
 
-At least one argument is required. If no arguments are provided, ((gui.vfx)) will return a Failure object and usage information. All parameters take a number ranging from ((%V0%)) to ((%V11%)). The default values are:
+At least one argument is required. If no arguments are provided, ((gui.vfx)) will return a ((%DFailure%)) object and usage information. All parameters take a number ranging from ((%V0%)) to ((%V11%)). The default values are:
 
 ```
 gui.vfx { bloom: 5, noise: 5, scan: 5, bend: 4 }


### PR DESCRIPTION
I just decided to check the entire wiki for any instance of a missing Success/Failure color, and add them where found. There wasn't that many.