### PR TITLE
add autoretirement page

### DIFF
--- a/docs/guides/misc/autoretirement.mdx
+++ b/docs/guides/misc/autoretirement.mdx
@@ -1,0 +1,19 @@
+---
+title: Auto-retirement for Inactive Users
+---
+
+Documentation for hackmud's automatic inactive account retirement.
+
+## Accounts with no activity for a duration of 60 days will automatically retire all users
+
+In order to preserve performance of the Multi-User Domain over time, it is necessary to remove users and records from the database. Users that belong to accounts which have gone inactive for 60 days will automatically retire.
+
+## Email Reminders
+
+Players who wish to be notified of retirement can sign up for reminder emails by creating a [hackmud forums](https://hackmud.com/forums) account, linked to the steam account which owns hackmud.
+
+## No Auto-retirement for Elite Supporters
+
+[Click here to check out our Supporter Model](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI)
+
+Players who are actively subscribed to our Elite Support tier (or above) will _not_ automatically retire until their Support Subscription ends, or drops below the Elite Tier monthly donation amount.

--- a/docs/guides/misc/autoretirement.mdx
+++ b/docs/guides/misc/autoretirement.mdx
@@ -10,7 +10,7 @@ In order to preserve performance of the Multi-User Domain over time, it is neces
 
 ## Email Reminders
 
-Players who wish to be notified of retirement can sign up for reminder emails by creating a [hackmud forums](https://hackmud.com/forums) account, linked to the steam account which owns hackmud.
+Players who wish to be notified of retirement can sign up for reminder emails by linking your steam account to the [hackmud forums](https://hackmud.com/forums).
 
 ## No Auto-retirement for Elite Supporters
 


### PR DESCRIPTION
### Problem

There is no page that describes Auto-Retirement, or how to sign up for email alerts/reminders about autoretirement

### Context

Adding a page that attempts to describe how auto-retirement works, why, and how to set up email reminders