### PR TITLE
add supporter model documentation

### DIFF
--- a/docs/guides/misc/supporter_benefits.mdx
+++ b/docs/guides/misc/supporter_benefits.mdx
@@ -4,6 +4,6 @@ title: Supporter Model and Benefits
 
 The [ComCODE Supporter Model](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI) intends to provide a way for anyone to support ComCODE's long term development of hackmud.
 
-By supporting [ComCODE](https://comcode.org/), you are making a 100% tax deductable donation on a monthly recurring basis. This will help us to achieve our goal of financial sustainability, so that we can continue to deliver on our mission.
+By supporting [ComCODE](https://comcode.org/) you are making a donation to ComCODE, a 501(c)-3 Non-Profit, on a monthly recurring basis. This will help us to achieve our goal of financial sustainability, so that we can continue to deliver on our mission.
 
 For more information about becoming a Supporter, and our Supporter Benefits, visit [our Supporter Campaign Page](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI).

--- a/docs/guides/misc/supporter_benefits.mdx
+++ b/docs/guides/misc/supporter_benefits.mdx
@@ -1,0 +1,9 @@
+---
+title: Supporter Model and Benefits
+---
+
+The [ComCODE Supporter Model](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI) intends to provide a way for anyone to support ComCODE's long term development of hackmud.
+
+By supporting [ComCODE](https://comcode.org/), you are making a 100% tax deductable donation on a monthly recurring basis. This will help us to achieve our goal of financial sustainability, so that we can continue to deliver on our mission.
+
+For more information about becoming a Supporter, and our Supporter Benefits, visit [our Supporter Campaign Page](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI).

--- a/docs/guides/misc/supporter_benefits.mdx
+++ b/docs/guides/misc/supporter_benefits.mdx
@@ -4,6 +4,6 @@ title: Supporter Model and Benefits
 
 The [ComCODE Supporter Model](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI) intends to provide a way for anyone to support ComCODE's long term development of hackmud.
 
-By supporting [ComCODE](https://comcode.org/) you are making a donation to ComCODE, a 501(c)-3 Non-Profit, on a monthly recurring basis. This will help us to achieve our goal of financial sustainability, so that we can continue to deliver on our mission.
+By supporting [ComCODE](https://comcode.org/) you are making a donation to ComCODE, a 501(c)(3) nonprofit organization, on a monthly recurring basis. This will help us to achieve our goal of financial sustainability, so that we can continue to deliver on our mission.
 
 For more information about becoming a Supporter, and our Supporter Benefits, visit [our Supporter Campaign Page](https://givebutter.com/QncoAxxT2tdWf3UfJ2x95z25n1HNizxI).


### PR DESCRIPTION
### Problem

There is no way for people to know about the supporter model, or benefits

### Context

add a page describing the supporter model and link to campaign