### PR TITLE
updated shift time

### DIFF
--- a/docs/guides/new_players/glossary.mdx
+++ b/docs/guides/new_players/glossary.mdx
@@ -175,7 +175,7 @@ See [PC](#pc).
 
 ### shift
 
-The process that assigns a script to a sector. Shifting a script takes 15 minutes, and is required with any sec level change of a public script, or when first making a script public.
+The process that assigns a script to a sector. Shifting a script takes 5 minutes, and is required with any sec level change of a public script, or when first making a script public.
 
 ### stuck NPCs
 


### PR DESCRIPTION
### Problem

The correct script shifting time is 5 minutes.

### Context

The script shifting time was previously 15 minutes and was changed to 5 minutes. The wiki page still reflects the 15 minute time.
