### PR TITLE
Changed shift timer in /docs/guides/new_player/glossary.mdx from 15m to 5m

### DIFF
--- a/docs/guides/new_players/glossary.mdx
+++ b/docs/guides/new_players/glossary.mdx
@@ -175,7 +175,7 @@ See [PC](#pc).
 
 ### shift
 
-The process that assigns a script to a sector. Shifting a script takes 15 minutes, and is required with any sec level change of a public script, or when first making a script public.
+The process that assigns a script to a sector. Shifting a script takes 5 minutes, and is required with any sec level change of a public script, or when first making a script public.
 
 ### stuck NPCs
 


### PR DESCRIPTION
### Problem

The shift timer in docs/guides/new_players/glossary.mdx was incorrect, stating 15m instead of 5m. Have edited it to be correct.