### PR TITLE
Fix `uniq` description and example

### DIFF
--- a/docs/scripting/scripts.lib/uniq.mdx
+++ b/docs/scripting/scripts.lib/uniq.mdx
@@ -4,7 +4,7 @@ title: .uniq()
 
 A function that deduplicates adjacent elements from an array, while preserving the order of the remaining elements.
 
-Similar to the *nix `uniq` command, duplicate values that are not adjacent are *not* removed.
+Similar to the \*nix `uniq` command, duplicate values that are not adjacent are _not_ removed.
 
 ## Syntax
 
@@ -29,7 +29,6 @@ function(context, args) {
   const l = #fs.scripts.lib();
   const my_array = ["apples", "apples", "bananas", "oranges", "apples", "limes"];
 
-  const uniq_array = l.uniq(my_array); // => ["apples", "bananas", "oranges", "apples", "limes"]
-  return uniq_array;
+  return l.uniq(my_array); // => ["apples", "bananas", "oranges", "apples", "limes"]
 }
 ```

--- a/docs/scripting/scripts.lib/uniq.mdx
+++ b/docs/scripting/scripts.lib/uniq.mdx
@@ -2,7 +2,9 @@
 title: .uniq()
 ---
 
-A function that deduplicates elements from an array, while preserving the order of the remaining elements.
+A function that deduplicates adjacent elements from an array, while preserving the order of the remaining elements.
+
+Similar to the *nix `uniq` command, duplicate values that are not adjacent are *not* removed.
 
 ## Syntax
 
@@ -25,8 +27,9 @@ Returns an array.
 ```js
 function(context, args) {
   const l = #fs.scripts.lib();
-  const my_array = ["apples", "bananas", "oranges", "apples", "limes", "oranges"];
+  const my_array = ["apples", "apples", "bananas", "oranges", "apples", "limes"];
 
-  return l.uniq(my_array);
+  const uniq_array = l.uniq(my_array); // => ["apples", "bananas", "oranges", "apples", "limes"]
+  return uniq_array;
 }
 ```


### PR DESCRIPTION
The article now mentions that only adjacent values are deduplicated. The output was added to the example.

### Problem

The wiki didn't mention the uniq(ue) behavior of `scripts.lib.uniq`, which was confusing me and some other people.
