### PR TITLE
Change arbitrary script execution mark from `context` to `unlock`

### DIFF
--- a/docs/guides/new_players/marks.mdx
+++ b/docs/guides/new_players/marks.mdx
@@ -11,7 +11,7 @@ The ((%QMarks System%)) is a means of tracking your progression through hackmud.
 
 ### How do I access locked scripts?
 
-Many scripts in [[scripts.trust:((scripts.trust))]] - as well as all other scripts uploaded by users - will be locked behind completing a relevant mark challenge. Currently, the ((%Qcontext%)) mark gates the execution of arbitrary user scripts, plus Trust scripts that are not otherwise unlocked during Required Marks.
+Many scripts in [[scripts.trust:((scripts.trust))]] - as well as all other scripts uploaded by users - will be locked behind completing a relevant mark challenge. Currently, the '((%Qunlock%))' mark gates the execution of arbitrary user scripts, plus Trust scripts that are not otherwise unlocked during Required Marks.
 
 Running a locked script will inform you of what challenge you must complete to unlock it, including ones which you may not yet have access to.
 


### PR DESCRIPTION
### Problem

The Marks System guide was out-of-date with respect to which mark gates arbitrary user script running; it's now `marks.unlock`

### Context

<!-- Additional context about how this fix was implemented. delete section if not needed -->
