### PR TITLE
Alias "bot_brain(s)" to cron_bot_v1

### DIFF
--- a/docs/upgrades/architect/cron_bot_v1.mdx
+++ b/docs/upgrades/architect/cron_bot_v1.mdx
@@ -1,9 +1,9 @@
 ---
 title: cron_bot_v1
-alias: 
-- cron_bot
-- bot_brain
-- bot_brains
+alias:
+  - cron_bot
+  - bot_brain
+  - bot_brains
 ---
 
 > bot_brain upgrades will call your bot_brain script based on the upgrade's cooldown interval, allowing you to automate your user.

--- a/docs/upgrades/architect/cron_bot_v1.mdx
+++ b/docs/upgrades/architect/cron_bot_v1.mdx
@@ -1,6 +1,9 @@
 ---
 title: cron_bot_v1
-alias: cron_bot
+alias: 
+- cron_bot
+- bot_brain
+- bot_brains
 ---
 
 > bot_brain upgrades will call your bot_brain script based on the upgrade's cooldown interval, allowing you to automate your user.


### PR DESCRIPTION
### Problem

There are some redlinks to `bot_brain` and `bot_brains` on the wiki which this resolves

### Context

Probably worth eventually writing a `bot_brains` guide article covering all of the weirdness abound in bot_brains, but this is a quick fix
