### PR TITLE
Fixed return type of .hash_code()

### DIFF
--- a/docs/scripting/scripts.lib/hash_code.mdx
+++ b/docs/scripting/scripts.lib/hash_code.mdx
@@ -18,7 +18,7 @@ The string to be hashed.
 
 ### Return
 
-Returns a string.
+Returns a number.
 
 ## Example
 


### PR DESCRIPTION
Fixed the return type from string to number
