### PR TITLE
Bump action versions in Deploy workflow

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build site
         run: pnpm build
       - name: Upload build artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Required due to an intentional deprecation/breakage on GitHub's side.

### Problem

Deployments are failing (e.g. <https://github.com/comcode-org/hackmud_wiki/actions/runs/13119582740/job/36602270862>)

### Context

This failure is due to an intentional breakage on GitHub's side: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.

`actions/upload-pages-artifact@v2` uses `actions/upload-artifact@v3` internally and needs to be updated to at least v3: https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0

This also requires `actions/deploy-pages@v4` as mentioned in the release notes for `actions/upload-pages-artifact@v3`.

