### PR TITLE
Add description of hackmud to main wiki page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,6 +7,8 @@ title: Home
 
 Welcome to the hackmud wiki!
 
+hackmud is a retro cyberpunk RPG where you play a digital persona in a chaotic, unpredictable, and often goofy abandoned internet. Enter a 90s hacker movie filled with scripts, scams, and sabotage. Explore the world of digital secrets and forge your legacy through cunning, creativity, or disruption.
+
 ### Looking for help?
 
 Use the nav bar at the top of the page to browse to the content you are looking for.


### PR DESCRIPTION
### Problem

helperbot doesn't know what our current hackmud short-description is, and neither does anyone stumbling onto our wiki from random searches!

### Context

<!-- Additional context about how this fix was implemented. delete section if not needed -->
