### PR TITLE
Patch trust_scripts doc card list to fit wiki styling + stay in-date

### DIFF
--- a/docs/scripting/trust_scripts.mdx
+++ b/docs/scripting/trust_scripts.mdx
@@ -1,12 +1,10 @@
-Trust scripts are scripts provided by trust herself. So you can trust them. Probably. ((%D:)%))
+Trust scripts are scripts provided by Trust herself, and thus can be trusted to act as-described. Probably. ((%D:)%))
 
-In the Hackmud shell, trust scripts are rendered with a "((%FSafety Orange%))" username, like "[((trust.me))](/scripting/trust_scripts/trust.me)." If you are trying to run a trust script at the shell, make sure you see the ((%FSafety Orange%)) before you press enter!
+In the hackmud shell, trust scripts are rendered with a "((%Fsafety orange%))" username, like "[((sys.upgrades))](/scripting/trust_scripts/sys.upgrades)". It is advised to verify this before pressing enter!
 
-You can list the trust scripts using [((scripts.trust))](/scripting/trust_scripts/scripts.trust).
-
-Trust scripts will also show "TRUST" for [((scripts.get_access_level))](/scripting/trust_scripts/scripts.get_access_level) (or ((trust: true)) for scripts.)
+Public Trust scripts can be listed in-game using [((scripts.trust))](/scripting/trust_scripts/scripts.trust). Trust scripts will also show "TRUST" in [((scripts.get_access_level))](/scripting/trust_scripts/scripts.get_access_level) (or ((trust: true)) when subscripted)
 
 {/* auto-generated list of category doc links: */}
 import DocCardList from "@theme/DocCardList";
 
-<DocCardList />;
+<DocCardList />


### PR DESCRIPTION
### Problem

https://wiki.hackmud.com/scripting/trust_scripts currently uses referential nouns (you, your) which the style guide aims to avoid. hackmud is written as `Hackmud`, which the style guide aims to avoid. `trust.me` is also used as an example of an orange-green script name which is no longer correct in-game.

### Context

<!-- Additional context about how this fix was implemented. delete section if not needed -->
