### PR TITLE
Trigger HELPERBOT brain update after Pages deploy

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -67,7 +67,7 @@ jobs:
     needs: deploy
     steps:
       - name: Trigger wiki update notification
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.DISCORD_DISPATCH_TOKEN }}
           repository: comcode-org/discord

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -60,3 +60,15 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  notify:
+    name: Trigger wiki update notification
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Trigger wiki update notification
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
+        with:
+          token: ${{ secrets.DISCORD_DISPATCH_TOKEN }}
+          repository: comcode-org/discord
+          event-type: wiki-updated


### PR DESCRIPTION
### Problem

When the wiki is published via GitHub Pages, HELPERBOT's brain content stays whatever it was -- there's no mechanism to refresh the OpenAI assistant's vector store with the new content. We added an automated workflow on \`comcode-org/discord\` that does the rebuild + flatten + push, but it currently only runs on manual \`workflow_dispatch\`. We want a successful wiki publish to fire it automatically.

### Context

Adds a \`notify\` job that runs after the \`deploy\` job succeeds and sends a \`repository_dispatch\` event to \`comcode-org/discord\` with event type \`wiki-updated\`. The discord repo's \`Update HELPERBOT brain\` workflow already listens for that event (landed on its main as of comcode-org/discord#87) and refreshes the assistant.

Uses \`peter-evans/repository-dispatch\` pinned to v4.0.1 (\`28959ce8df70de7be546dd1250a005dd32156697\`). The action is ~30 lines of TS, MIT-licensed, ~1.2k stars, last released 2025-11-14, depends only on \`@actions/core\` and \`@actions/github\`. It does exactly one thing: calls \`octokit.rest.repos.createDispatchEvent\`.

Auth uses a fine-grained PAT stored as \`DISCORD_DISPATCH_TOKEN\` on this repo, scoped to \`actions:write\` on \`comcode-org/discord\` only.

Test plan after merge:

- Smoke test by triggering the deploy workflow manually:
  \`\`\`
  gh workflow run "Deploy Docusaurus site to GitHub Pages" --repo comcode-org/hackmud_wiki
  \`\`\`
- Watch this repo's run complete the new \`notify\` job, then check that a fresh run appears on the discord side with \`event: repository_dispatch\`:
  \`\`\`
  gh run list --repo comcode-org/discord --workflow "Update HELPERBOT brain" --limit 1
  \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)